### PR TITLE
Remove rocprofiler from dependencies

### DIFF
--- a/rocm-dev/.SRCINFO
+++ b/rocm-dev/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-dev
 	pkgdesc = ROCm Dev - Metapackage for the ROCm Development Stack
 	pkgver = 3.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
 	depends = rocm-comgr
@@ -12,7 +12,6 @@ pkgbase = rocm-dev
 	depends = rocm-cmake
 	depends = rocm-device-libs
 	depends = rocm-smi
-	depends = rocprofiler
 	depends = rocr-debug-agent
 	depends = rocm-utils
 

--- a/rocm-dev/PKGBUILD
+++ b/rocm-dev/PKGBUILD
@@ -7,8 +7,7 @@ arch=('x86_64')
 url="https://rocm-documentation.readthedocs.io/en/latest/"
 license=()
 depends=('rocm-comgr' 'hcc' 'hip-hcc' 'roct-thunk-interface' 'rocr-runtime'
-'rocm-cmake' 'rocm-device-libs' 'rocm-smi' 'rocprofiler' 'rocr-debug-agent'
-'rocm-utils')
+'rocm-cmake' 'rocm-device-libs' 'rocm-smi' 'rocr-debug-agent' 'rocm-utils')
 makedepends=()
 source=()
 sha256sums=()

--- a/rocm-dev/PKGBUILD
+++ b/rocm-dev/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rocm-dev
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROCm Dev - Metapackage for the ROCm Development Stack"
 arch=('x86_64')
 url="https://rocm-documentation.readthedocs.io/en/latest/"


### PR DESCRIPTION
Fixes #49 

Relevant upstream discussion:
https://github.com/ROCm-Developer-Tools/rocprofiler/issues/18