### PR TITLE
Fix rocprofiler package

### DIFF
--- a/rocprofiler/.SRCINFO
+++ b/rocprofiler/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = rocprofiler
 	pkgdesc = ROC profiler library. Profiling with perf-counters and derived metrics.
 	pkgver = 3.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCm-Developer-Tools/rocprofiler
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
-	depends = rocm
+	depends = rocr-runtime
 	depends = python
 	depends = python-argparse
 	depends = python-cppheaderparser

--- a/rocprofiler/PKGBUILD
+++ b/rocprofiler/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rocprofiler
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROC profiler library. Profiling with perf-counters and derived metrics."
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/rocprofiler"
 license=('MIT')
-depends=('rocm' 'python' 'python-argparse' 'python-cppheaderparser')
+depends=('rocr-runtime' 'python' 'python-argparse' 'python-cppheaderparser')
 makedepends=('cmake')
 options=(!staticlibs strip)
 source=("rocprofiler-roc-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/rocprofiler/archive/roc-$pkgver.tar.gz")
@@ -17,7 +17,7 @@ build() {
   cd "$srcdir/build"
 
   cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm/rocprofiler \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         "$srcdir/rocprofiler-roc-$pkgver"
   make
 }


### PR DESCRIPTION
The CMakeLists.txt of this projects suggests that rocprofiler only
depends on rocr-runtime:

    ## Debian package specific variables
    set ( CPACK_DEBIAN_PACKAGE_DEPENDS "hsa-rocr-dev" )

The configuration error was caused by a wrong CMAKE_INSTALL_PREFIX
which should point to /opt/rocm, not /opt/rocm/rocprofiler.