### PR TITLE
Fix roctracer

### DIFF
--- a/roctracer/.SRCINFO
+++ b/roctracer/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = roctracer
 	pkgdesc = ROCm Tracer Callback/Activity Library for Performance tracing AMD GPU's
 	pkgver = 3.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCm-Developer-Tools/roctracer
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
-	depends = rocm
+	depends = rocr-runtime
 	depends = python
 	depends = python-argparse
 	depends = python-cppheaderparser

--- a/roctracer/PKGBUILD
+++ b/roctracer/PKGBUILD
@@ -1,23 +1,31 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=roctracer
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROCm Tracer Callback/Activity Library for Performance tracing AMD GPU's"
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/roctracer"
 license=('MIT')
-depends=('rocm' 'python' 'python-argparse' 'python-cppheaderparser')
+depends=('rocr-runtime' 'python' 'python-argparse' 'python-cppheaderparser')
+optdepends=('hip: tracing for higher level interface')
 makedepends=('cmake')
 options=(!staticlibs strip)
 source=("roctracer-roc-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/roctracer/archive/roc-$pkgver.tar.gz")
 sha256sums=('1339dac1d55f7bd2385894f9597fa0f1c8a50d9afe689951ea2dac78d22efdbb')
+
+prepare() {
+    local _fn
+    for _fn in $srcdir/roctracer-roc-$pkgver/{bin,script}/*.py; do
+        2to3 -w $_fn
+    done
+}
 
 build() {
   mkdir -p "$srcdir/build"
   cd "$srcdir/build"
 
   cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm/roctracer \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         "$srcdir/roctracer-roc-$pkgver"
   make
 }
@@ -26,11 +34,4 @@ package() {
   cd "$srcdir/build"
 
   make DESTDIR="$pkgdir" install
-
-  # add links
-  install -d "$pkgdir/usr/bin"
-  local _fn
-  for _fn in roctracer; do
-    ln -s "/opt/rocm/roctracer/bin/$_fn" "$pkgdir/usr/bin/$_fn"
-  done
 }


### PR DESCRIPTION
* roctracer is a library and does not ship with an executable -> Delete
  symlinks
* Fix CMAKE_PREFIX_INSTALL_PATH which should not include roctracer
* Convert python2 scripts to python3 code via 2to3