### PR TITLE
Update python2 fix on rocm-smi to cover more warnings

### DIFF
--- a/rocm-smi/.SRCINFO
+++ b/rocm-smi/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-smi
 	pkgdesc = Utility to manage and monitor AMDGPU / ROCm systems.
 	pkgver = 3.1.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/ROC-smi/
 	arch = any
 	license = MIT
@@ -9,7 +9,7 @@ pkgbase = rocm-smi
 	source = rocm-smi-3.1.0.tar.gz::https://github.com/RadeonOpenCompute/ROC-smi/archive/roc-3.1.0.tar.gz
 	source = python2_fix.patch
 	sha256sums = df8a1f646ad0bfa6c8a0a0545b55e79514f22319df92a2d8290fd4aa58aaaf61
-	sha256sums = f49b7035dfd9bee2bafb633c3b54e011bbb05d3b5a495937d655ef0fd377b462
+	sha256sums = acff646a9ffdd338f25c8fcdc2282cbd7039ef80f215f4a5ab2fbfdde2705781
 
 pkgname = rocm-smi
 

--- a/rocm-smi/PKGBUILD
+++ b/rocm-smi/PKGBUILD
@@ -1,7 +1,9 @@
 # Maintainer: Rigo Reddig <rigo.reddig@gmail.com>
+# Contributor: Ranieri Althoff <ranisalt+aur at gmail dot com>
+
 pkgname=rocm-smi
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 _filename=roc-${pkgver}.tar.gz
 pkgdesc="Utility to manage and monitor AMDGPU / ROCm systems."
 arch=('any')
@@ -13,11 +15,11 @@ source=(
   "python2_fix.patch"
 )
 sha256sums=('df8a1f646ad0bfa6c8a0a0545b55e79514f22319df92a2d8290fd4aa58aaaf61'
-            'f49b7035dfd9bee2bafb633c3b54e011bbb05d3b5a495937d655ef0fd377b462')
+            'acff646a9ffdd338f25c8fcdc2282cbd7039ef80f215f4a5ab2fbfdde2705781')
 
 prepare() {
 	cd "${srcdir}/ROC-smi-roc-$pkgver"
-	patch --forward --strip=1 --input="${srcdir}/python2_fix.patch"
+	patch -Np1 -i "${srcdir}/python2_fix.patch"
 }
 
 package() {

--- a/rocm-smi/python2_fix.patch
+++ b/rocm-smi/python2_fix.patch
@@ -1,9 +1,70 @@
-diff --unified --recursive --text ROC-smi-roc-3.0.0/rocm_smi.py ROC-smi-roc-3.0.0/rocm_smi.py
---- ROC-smi-roc-3.0.0/rocm_smi.py	2019-12-03 20:15:25.000000000 +0100
-+++ ROC-smi-roc-3.0.0/rocm_smi.py	2020-01-10 08:08:23.885794471 +0100
-@@ -1,4 +1,4 @@
--#!/usr/bin/env python
-+#!/usr/bin/env python2.7
- """ ROCm-SMI (System Management Interface) Tool
+diff --git a/rocm_smi.py b/rocm_smi.py
+index 7b36028..8ba2bd0 100755
+--- a/rocm_smi.py
++++ b/rocm_smi.py
+@@ -739,7 +739,7 @@ def getCurrentClock(device, clock, clocktype):
+     # Hack: In the kernel, FCLK doesn't have an * at all if DPM is disabled.
+     # If there is only 1 speed (1 line total, meaning 0 levels), just print it
+     if len(currClocks.splitlines()) == 1 and len(currClocks) > 1:
+-        if clocktype is 'freq':
++        if clocktype == 'freq':
+             if currClocks.find('DPM disabled'):
+                 logging.debug('Only 1 level for clock %s; DPM is disabled for this specific clock' % clock)
+             return currClocks.split(' *')[0][3:]
+@@ -824,7 +824,7 @@ def getVersion(deviceList, component):
+     deviceList -- List of DRM devices (can be a single-item list)
+     component - Component (currently only driver)
+     """
+-    if component is 'driver':
++    if component == 'driver':
+         # Only 1 version, so report it for GPU 0
+         driver = getSysfsValue(None, 'driver')
+         if driver is None:
+@@ -846,10 +846,10 @@ def getRetiredPages(device, retiredType):
+         return None
+     for line in pages.split('\n'):
+         pgType = line.split(' : ')[-1]
+-        if (retiredType is 'all' or \
+-           retiredType is 'retired' and pgType is 'R' or \
+-           retiredType is 'pending' and pgType is 'P' or \
+-           retiredType is 'unreservable' and pgType is 'F'):
++        if (retiredType == 'all' or \
++           retiredType == 'retired' and pgType == 'R' or \
++           retiredType == 'pending' and pgType == 'P' or \
++           retiredType == 'unreservable' and pgType == 'F'):
+             returnPages += '\n%s' % line
+     return returnPages.lstrip('\n')
  
- This tool provides a user-friendly interface for manipulating
+@@ -1424,7 +1424,7 @@ def showVersion(deviceList, component):
+     if component not in validVersionComponents:
+         printLog(device, 'Unable to display version information for unsupported component %s' % component)
+         return
+-    if component is 'driver':
++    if component == 'driver':
+         driver = getVersion(deviceList, component)
+         printSysLog('%s version: %s' % (component.capitalize(), driver))
+ 
+@@ -1824,9 +1824,9 @@ def showRetiredPages(deviceList, retiredType='all'):
+                 addr = line.split(' : ')[0]
+                 size = line.split(' : ')[1]
+                 ptype = line.split(' : ')[2]
+-                if ptype is 'R':
++                if ptype == 'R':
+                     pgType = 'Retired'
+-                elif ptype is 'P':
++                elif ptype == 'P':
+                     pgType = 'Pending'
+                 else:
+                     pgType = 'Unreservable'
+@@ -2281,9 +2281,9 @@ def setClockRange(deviceList, clktype, level, value, autoRespond):
+         logging.error('Non-integer characters are present in %s', value)
+         RETCODE = 1
+         return
+-    if clkType is 'sclk':
++    if clkType == 'sclk':
+         sysvalue = 's %s %s' % (level, value)
+-    elif clkType is 'mclk':
++    elif clkType == 'mclk':
+         sysvalue = 'm %s %s' % (level, value)
+     else:
+         printLogNoDev('Invalid clock type %s' % clkType)


### PR DESCRIPTION
Running `rocm-smi` throws a lot of syntax warnings related to invalid usage of Python (`is` instead of `==` with strings). Also, the current patch is outdated and was already applied to upstream.