### PR TITLE
Split rocm-opencl-runtime and rocm-device-libs

### DIFF
--- a/rocm-device-libs/.SRCINFO
+++ b/rocm-device-libs/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = rocm-device-libs
+	pkgdesc = Radeon Open Compute - device libs
+	pkgver = 3.1.0
+	pkgrel = 3
+	url = https://github.com/RadeonOpenCompute/ROCm-Device-Libs
+	arch = x86_64
+	license = custom
+	makedepends = cmake
+	makedepends = git
+	makedepends = llvm-roc
+	makedepends = rocm-cmake
+	source = https://github.com/RadeonOpenCompute/ROCm-Device-Libs/archive/roc-ocl-3.1.0.tar.gz
+	sha256sums = SKIP
+
+pkgname = rocm-device-libs
+

--- a/rocm-device-libs/.SRCINFO
+++ b/rocm-device-libs/.SRCINFO
@@ -4,13 +4,12 @@ pkgbase = rocm-device-libs
 	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/ROCm-Device-Libs
 	arch = x86_64
-	license = custom
+	license = custom:NCSAOSL
 	makedepends = cmake
-	makedepends = git
 	makedepends = llvm-roc
 	makedepends = rocm-cmake
 	source = https://github.com/RadeonOpenCompute/ROCm-Device-Libs/archive/roc-ocl-3.1.0.tar.gz
-	sha256sums = SKIP
+	sha256sums = bce5da4adba4ea360cd4a8aff39d25d0d8a900bdd13aff0482b685bb495508f6
 
 pkgname = rocm-device-libs
 

--- a/rocm-device-libs/PKGBUILD
+++ b/rocm-device-libs/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Ranieri Althoff <ranisalt+aur at gmail dot com>
+
+pkgname=rocm-device-libs
+pkgver=3.1.0
+pkgrel=3
+pkgdesc='Radeon Open Compute - device libs'
+license=('custom')
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/ROCm-Device-Libs'
+makedepends=(cmake git llvm-roc rocm-cmake)
+source=("$url/archive/roc-ocl-$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+_dirname="ROCm-Device-Libs-roc-ocl-$pkgver"
+
+build() {
+  cd "$srcdir/$_dirname/utils"
+  cmake -DLLVM_DIR=/opt/rocm/lib/cmake/llvm .
+  make
+
+  cd "$srcdir"
+  cmake \
+    -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+    -DLLVM_DIR=/opt/rocm/lib/cmake/llvm \
+    -DPREPARE_BUILTINS="$srcdir/$_dirname/utils/prepare-builtins/prepare-builtins" \
+    -DROCM_DIR=/opt/rocm/share/rocm/cmake \
+    "$_dirname"
+  make
+}
+
+package() {
+    DESTDIR="$pkgdir/" make install
+
+    install -Dm644 "$_dirname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/rocm-device-libs/PKGBUILD
+++ b/rocm-device-libs/PKGBUILD
@@ -4,12 +4,12 @@ pkgname=rocm-device-libs
 pkgver=3.1.0
 pkgrel=3
 pkgdesc='Radeon Open Compute - device libs'
-license=('custom')
+license=('custom:NCSAOSL')
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/ROCm-Device-Libs'
-makedepends=(cmake git llvm-roc rocm-cmake)
+makedepends=(cmake llvm-roc rocm-cmake)
 source=("$url/archive/roc-ocl-$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('bce5da4adba4ea360cd4a8aff39d25d0d8a900bdd13aff0482b685bb495508f6')
 
 _dirname="ROCm-Device-Libs-roc-ocl-$pkgver"
 

--- a/rocm-opencl-runtime/.SRCINFO
+++ b/rocm-opencl-runtime/.SRCINFO
@@ -1,38 +1,30 @@
 pkgbase = rocm-opencl-runtime
+	pkgdesc = Radeon Open Compute - OpenCL runtime
 	pkgver = 3.1.0
 	pkgrel = 2
-	url = https://github.com/RadeonOpenCompute
+	url = https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime
 	arch = x86_64
+	license = MIT
 	makedepends = mesa
 	makedepends = cmake
 	makedepends = git
 	makedepends = llvm-roc
-	makedepends = rocm-comgr
-	provides = rocm-device-libs
+	makedepends = rocm-cmake
+	depends = hsakmt-roct>=3.1.0
+	depends = rocm-comgr>=3.1.0
+	depends = rocr-runtime>=3.1.0
+	depends = opencl-icd-loader
 	provides = opencl-driver
-	source = rocm-device-libs::git+https://github.com/RadeonOpenCompute/ROCm-Device-Libs#tag=roc-ocl-3.1.0
-	source = rocm-opencl-runtime::git+https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime#tag=roc-3.1.0
-	source = rocm-cmake::git+https://github.com/RadeonOpenCompute/rocm-cmake#tag=roc-3.0.0
-	source = opencl-icd-loader::git+https://github.com/KhronosGroup/OpenCL-ICD-Loader#commit=978b4b3a29a3aebc86ce9315d5c5963e88722d03
+	source = https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.1.0.tar.gz
+	source = https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/978b4b3a29a3aebc86ce9315d5c5963e88722d03.tar.gz
 	source = rocm-opencl-runtime-2.8.0-change-opencl.patch
 	source = rocm-opencl-runtime-2.8.0-amdocl64icd.patch
 	source = rocm-opencl-runtime-3.0.0-change-install-location.patch
-	sha256sums = SKIP
-	sha256sums = SKIP
-	sha256sums = SKIP
-	sha256sums = SKIP
+	sha256sums = c14f544daef32e991af4f356825d1e9cb99ddad4a58ba7dda6054603a9c5d1b8
+	sha256sums = 0c14bf890bd198ef5a814b5b7ed57b69e890b0c0a1bcfba8fdad996fa1a97fc7
 	sha256sums = 3af5c9c3b8b88b78a2fd574f339e88a5cd62c365d94e9289c2a2cb4afef3d435
 	sha256sums = 2cfd11bda9a485d6de2231c56742ad553329cab9b6dcc009dbddbcde1436f485
 	sha256sums = 941a29f8704a2839c32bcf3cf374dde30bc8a839c1136d4faa65c60a7500cf98
 
-pkgname = rocm-device-libs
-	pkgdesc = Radeon Open Compute - device libs
-	license = unknown
-
 pkgname = rocm-opencl-runtime
-	pkgdesc = Radeon Open Compute - OpenCL runtime
-	license = MIT
-	depends = hsakmt-roct>=3.1.0
-	depends = rocr-runtime>=3.1.0
-	depends = opencl-icd-loader
 

--- a/rocm-opencl-runtime/PKGBUILD
+++ b/rocm-opencl-runtime/PKGBUILD
@@ -2,104 +2,69 @@
 
 _opencl_icd_loader_commit='978b4b3a29a3aebc86ce9315d5c5963e88722d03'
 
-pkgbase=rocm-opencl-runtime
-pkgname=(rocm-device-libs rocm-opencl-runtime)
+pkgname=rocm-opencl-runtime
 pkgver=3.1.0
 pkgrel=2
+pkgdesc='Radeon Open Compute - OpenCL runtime'
+license=('MIT')
 arch=('x86_64')
-url='https://github.com/RadeonOpenCompute'
-makedepends=(mesa cmake git llvm-roc rocm-comgr)
-provides=("$pkgname" 'opencl-driver')
+url='https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime'
+depends=("hsakmt-roct>=$pkgver" "rocm-comgr>=$pkgver" "rocr-runtime>=$pkgver" 'opencl-icd-loader')
+makedepends=(mesa cmake git llvm-roc rocm-cmake)
+provides=('opencl-driver')
 source=(
-    "rocm-device-libs::git+https://github.com/RadeonOpenCompute/ROCm-Device-Libs#tag=roc-ocl-$pkgver"
-    "rocm-opencl-runtime::git+https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime#tag=roc-$pkgver"
-    "rocm-cmake::git+https://github.com/RadeonOpenCompute/rocm-cmake#tag=roc-3.0.0"
-    "opencl-icd-loader::git+https://github.com/KhronosGroup/OpenCL-ICD-Loader#commit=$_opencl_icd_loader_commit"
+    "$url/archive/roc-$pkgver.tar.gz"
+    "https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/$_opencl_icd_loader_commit.tar.gz"
     # "rocm-opencl-runtime-2.8.0-change-AMDCompilerh.patch"
     "rocm-opencl-runtime-2.8.0-change-opencl.patch"
     "rocm-opencl-runtime-2.8.0-amdocl64icd.patch"
     "rocm-opencl-runtime-3.0.0-change-install-location.patch"
 )
 
-sha256sums=('SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
+sha256sums=('c14f544daef32e991af4f356825d1e9cb99ddad4a58ba7dda6054603a9c5d1b8'
+            '0c14bf890bd198ef5a814b5b7ed57b69e890b0c0a1bcfba8fdad996fa1a97fc7'
             '3af5c9c3b8b88b78a2fd574f339e88a5cd62c365d94e9289c2a2cb4afef3d435'
             '2cfd11bda9a485d6de2231c56742ad553329cab9b6dcc009dbddbcde1436f485'
             '941a29f8704a2839c32bcf3cf374dde30bc8a839c1136d4faa65c60a7500cf98')
 
+_dirname="ROCm-OpenCL-Runtime-roc-$pkgver"
+
 prepare() {
-    cd "$srcdir/rocm-opencl-runtime"
+  cd "$_dirname"
 
-    # [ -d tools/clinfo ] && rm -rf tools/clinfo
+  # [ -d tools/clinfo ] && rm -rf tools/clinfo
 
-    mkdir -p api/opencl/khronos
-    mv "$srcdir/opencl-icd-loader" api/opencl/khronos/icd
+  mkdir -p api/opencl/khronos
+  mv "$srcdir/OpenCL-ICD-Loader-$_opencl_icd_loader_commit" api/opencl/khronos/icd
 
-    local src
-    for src in "${source[@]}"; do
-        src="${src%%::*}"
-        src="${src##*/}"
-        [[ $src = *.patch ]] || continue
-        msg2 "Applying patch $src..."
-        patch -Np1 -i "$srcdir/$src"
-    done
+  local src
+  for src in "${source[@]}"; do
+    src="${src%%::*}"
+    src="${src##*/}"
+    [[ $src = *.patch ]] || continue
+    msg2 "Applying patch $src..."
+    patch -Np1 -i "$srcdir/$src"
+  done
 }
 
 build() {
-    CMAKE_FLAGS=(
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_INSTALL_PREFIX='/opt/rocm'
-        -DLLVM_DIR=/opt/rocm/lib/cmake/llvm
-    )
-    if check_buildoption "ccache" "y"; then
-        CMAKE_FLAGS+=(-DROCM_CCACHE_BUILD=ON)
-    fi
-
-    msg2 'Building prepare builtins...'
-    cd "$srcdir/rocm-device-libs/utils"
-    cmake ${CMAKE_FLAGS[@]} ..
-    make
-
-    msg2 'Building device libs...'
-    cd "$srcdir/rocm-device-libs"
-    mkdir -p build && cd build
-    cmake ${CMAKE_FLAGS[@]} \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DPREPARE_BUILTINS="$srcdir/rocm-device-libs/utils/utils/prepare-builtins/prepare-builtins" \
-        ..
-    make
-
-    msg2 'Building OpenCL runtime...'
-    cd "$srcdir/rocm-opencl-runtime"
-    mkdir -p build && cd build
-    cmake ${CMAKE_FLAGS[@]} \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
-        -DCMAKE_MODULE_PATH="$srcdir/rocm-cmake/share/rocm/cmake" \
-        -DCMAKE_PREFIX_PATH=/opt/rocm/lib/cmake \
-        -DUSE_COMGR_LIBRARY=yes \
-        ..
-    make
+  cmake \
+    -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+    -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+    -DCMAKE_MODULE_PATH="$srcdir/rocm-cmake/share/rocm/cmake" \
+    -DCMAKE_PREFIX_PATH=/opt/rocm/lib/cmake \
+    -DLLVM_DIR=/opt/rocm/lib/cmake/llvm \
+    -DUSE_COMGR_LIBRARY=yes \
+    "$_dirname"
+  make
 }
 
-package_rocm-device-libs() {
-    pkgdesc='Radeon Open Compute - device libs'
-    license=('unknown')
+package() {
+  DESTDIR="$pkgdir/" make install
 
-    DESTDIR="$pkgdir/" make -C "$srcdir/rocm-device-libs/build" install
-}
-
-package_rocm-opencl-runtime() {
-    pkgdesc='Radeon Open Compute - OpenCL runtime'
-    depends=("hsakmt-roct>=${pkgver}" "rocr-runtime>=${pkgver}" 'opencl-icd-loader')
-    license=('MIT')
-
-    DESTDIR="$pkgdir/" make -C "$srcdir/rocm-opencl-runtime/build" install
-
-    mkdir -p "$pkgdir/etc/ld.so.conf.d"
-    echo '/opt/rocm/lib' > "$pkgdir/etc/ld.so.conf.d/rocm-opencl.conf"
-
-    install -Dm644 "$srcdir/rocm-opencl-runtime/License" "$pkgdir/usr/share/licenses/rocm-opencl-runtime/LICENSE"
+  install -Dm644 "$_dirname/License" "$pkgdir/usr/share/licenses/rocm-opencl-runtime/LICENSE"
+  install -d "$pkgdir/etc/ld.so.conf.d"
+  cat << EOF > "$pkgdir/etc/ld.so.conf.d/$pkgname.conf"
+/opt/rocm/lib
+EOF
 }


### PR DESCRIPTION
`rocm-device-libs` is used by `rocm-comgr` (it builds fine without, but doesn't work), so I am splitting the packages as the requirement tree is `device-libs` -> `comgr` -> `opencl-runtime` and it would cycle.

While at it, as it requires bumping pkgrel, I changed `opencl-runtime` to point to gzip source, not cloning from github, and made it use `rocm-cmake` instead of downloading it's own.