### PR TITLE
[hip-hcc] Add missing python build dependency

### DIFF
--- a/hip-hcc/.SRCINFO
+++ b/hip-hcc/.SRCINFO
@@ -1,12 +1,13 @@
 pkgbase = hip-hcc
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.1.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCm-Developer-Tools/HIP
 	arch = x86_64
 	license = MIT
 	makedepends = libelf
 	makedepends = cmake
+	makedepends = python
 	makedepends = hcc
 	makedepends = rocm-comgr
 	provides = hip

--- a/hip-hcc/PKGBUILD
+++ b/hip-hcc/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-hcc
 pkgver=3.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/HIP"
 license=('MIT')
-makedepends=('libelf' 'cmake' 'hcc' 'rocm-comgr')
+makedepends=('libelf' 'cmake' 'python' 'hcc' 'rocm-comgr')
 provides=('hip')
 conflicts=('hip')
 source=("https://github.com/ROCm-Developer-Tools/HIP/archive/roc-$pkgver.tar.gz")


### PR DESCRIPTION
This fixes issue #68 for `hip-hcc`