### PR TITLE
Bring hsa-ext-rocr up to the standard

### DIFF
--- a/hsa-ext-rocr/PKGBUILD
+++ b/hsa-ext-rocr/PKGBUILD
@@ -1,29 +1,21 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 # Contributor: Bruno Filipe <bmilreu@gmail.com>
+# Contributor: Ranieri Althoff <ranisalt+aur at gmail.com>
+
 pkgname=hsa-ext-rocr
-pkgver=1.1.30100
+pkgver=3.1.0
 pkgrel=1
 _debfile=hsa-ext-rocr-dev_1.1.30100.0-rocm-rel-3.1-44-ecafeba1_amd64.deb
-pkgdesc="ROCm Platform Runtime: Closed source components"
+pkgdesc='ROCm Platform Runtime: Closed source components'
 arch=('x86_64')
-url="https://github.com/RadeonOpenCompute/ROCm"
+url='https://github.com/RadeonOpenCompute/ROCR-Runtime'
 license=('EULA')
-groups=()
-depends=(hsa-rocr hsakmt-roct)
-makedepends=()
-provides=("${pkgname%-git}")
-conflicts=("${pkgname%-git}")
-replaces=()
-backup=()
-options=()
-source=("http://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/${_debfile}")
+depends=("hsa-rocr>=$pkgver" "hsakmt-roct>=$pkgver")
+source=("http://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/$_debfile")
 sha256sums=('fadff558ed486967ab048f6e393d13bfa9f1b480bcf37da9e41b44f4d99b218a')
 
 package() {
-	cd "$srcdir"
-	tar xf data.tar.gz
-
-	mkdir -p ${pkgdir}/usr/lib
-
-	cp -ax opt/rocm-3.1.0/hsa/lib/* ${pkgdir}/usr/lib
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
 }


### PR DESCRIPTION
It has the same version problem of #82 but this time I bumped the version. Let me know what will stick so I fix the other package. Also fixes permissions on folders (AMD insists on making folders group-writable for some reason)