### PR TITLE
Update rock-dkms version to 3.3.19

### DIFF
--- a/rock-dkms-git/PKGBUILD
+++ b/rock-dkms-git/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Markus Näther <naetherm@informatik.uni-freiburg.de>
 # Maintainer: Olaf Leidinger <oleid@mescharet.de>
 pkgname=rock-dkms-git
-pkgver=3.1.35
-_pkgver=3.1-35
+pkgver=3.3.19
+_pkgver=3.3-19
 pkgrel=1
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')
@@ -14,7 +14,7 @@ conflicts=('rock-dkms')
 backup=('etc/modprobe.d/blacklist-radeon.conf')
 options=('!strip' '!emptydirs')
 source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb")
-sha256sums=('21f6caf7ffc4ef29a6cde7353fd9e2d0fc97d9e9755c62bc6af7a736126925c2')
+sha256sums=('9a6eb2b65360b5ec74de3212030506ae6706bd29dc65d45582dc9d61f16dd5a3')
 
 package() {
   cd "$srcdir"

--- a/rock-dkms/PKGBUILD
+++ b/rock-dkms/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Olaf Leidinger <oleid@mescharet.de>
 pkgname=rock-dkms
-pkgver=3.1.44
-_pkgver=3.1-44
+pkgver=3.3.19
+_pkgver=3.3-19
 pkgrel=1
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')
@@ -11,7 +11,7 @@ depends=('dkms>=1.95')
 backup=('etc/modprobe.d/blacklist-radeon.conf')
 options=('!strip' '!emptydirs')
 source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb")
-sha256sums=('6d79b2162d1c0dc925afa62103f6fe28618c851dd345abf28cbb1346288d4a53')
+sha256sums=('9a6eb2b65360b5ec74de3212030506ae6706bd29dc65d45582dc9d61f16dd5a3')
 
 package() {
   cd "$srcdir"


### PR DESCRIPTION
Because 3.1.35 does not exist anymore in the radeon repo http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/