### PR TITLE
[hsa-rocr] Release build to suppress warnings

### DIFF
--- a/hsa-rocr/.SRCINFO
+++ b/hsa-rocr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hsa-rocr
 	pkgdesc = ROCm Platform Runtime: ROCr a HPC market enhanced HSA based runtime
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/ROCR-Runtime
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/hsa-rocr/PKGBUILD
+++ b/hsa-rocr/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=hsa-rocr
 pkgver=3.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc='ROCm Platform Runtime: ROCr a HPC market enhanced HSA based runtime'
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/ROCR-Runtime'
@@ -23,6 +23,7 @@ build() {
   cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DHSAKMT_INC_PATH=/opt/rocm/include \
         -DHSAKMT_LIB_PATH=/opt/rocm/lib \
+        -DCMAKE_BUILD_TYPE=Release \
         "$_dirname/src"
   make
 }


### PR DESCRIPTION
This PR fixes #92 
The warnings

    LoadLib(libhsa-ext-finalize64.so.1) failed: libhsa-ext-finalize64.so.1: cannot open shared object file: No such file or directory

are only visible in debug builds, see https://github.com/RadeonOpenCompute/ROCR-Runtime/issues/89.
Adding "-DCMAKE_BUILD_TYPE=Release" fixes this issue.