### PR TITLE
Revert "[hsa-rocr] Release build to suppress warnings"

### DIFF
--- a/hsa-rocr/.SRCINFO
+++ b/hsa-rocr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hsa-rocr
 	pkgdesc = ROCm Platform Runtime: ROCr a HPC market enhanced HSA based runtime
 	pkgver = 3.3.0
-	pkgrel = 3
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/ROCR-Runtime
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/hsa-rocr/PKGBUILD
+++ b/hsa-rocr/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=hsa-rocr
 pkgver=3.3.0
-pkgrel=3
+pkgrel=2
 pkgdesc='ROCm Platform Runtime: ROCr a HPC market enhanced HSA based runtime'
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/ROCR-Runtime'
@@ -23,7 +23,6 @@ build() {
   cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DHSAKMT_INC_PATH=/opt/rocm/include \
         -DHSAKMT_LIB_PATH=/opt/rocm/lib \
-        -DCMAKE_BUILD_TYPE=Release \
         "$_dirname/src"
   make
 }


### PR DESCRIPTION
Setting the build type on CMake will override and discard environment CFLAGS/CXXFLAGS, therefore not honoring the user's choice. That is precisely why the arch-meson helper script uses --buildtype=plain, not --buildtype=optimized.

Warnings are not errors, one should not dismiss the user's choice to suppress messages that do not interfere with the software execution.