### PR TITLE
Llvm-amdgpu static

### DIFF
--- a/comgr/.SRCINFO
+++ b/comgr/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = comgr
 	pkgdesc = Radeon Open Compute - compiler support
 	pkgver = 3.3.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/ROCm-CompilerSupport
 	arch = x86_64
 	license = custom:NCSAOSL
 	makedepends = cmake
 	makedepends = rocm-cmake
 	makedepends = rocm-device-libs
-	depends = llvm-amdgpu
+	makedepends = llvm-amdgpu
 	source = https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/rocm-3.3.0.tar.gz
 	source = comgr-find-lld-includes.patch
 	sha256sums = 01e2524e0f28ecd6f46c9720f279207de935d826b0172158792aa3ec86af9ca7

--- a/comgr/PKGBUILD
+++ b/comgr/PKGBUILD
@@ -3,12 +3,12 @@
 pkgname=comgr
 pkgdesc='Radeon Open Compute - compiler support'
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/ROCm-CompilerSupport'
 license=('custom:NCSAOSL')
-depends=(llvm-amdgpu)
-makedepends=(cmake rocm-cmake rocm-device-libs)
+depends=()
+makedepends=(cmake rocm-cmake rocm-device-libs llvm-amdgpu)
 source=("$url/archive/rocm-$pkgver.tar.gz"
         "comgr-find-lld-includes.patch")
 sha256sums=('01e2524e0f28ecd6f46c9720f279207de935d826b0172158792aa3ec86af9ca7'
@@ -23,6 +23,7 @@ build() {
   cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DCMAKE_PREFIX_PATH="/opt/rocm/llvm;/opt/rocm" \
         "$_dirname/lib/comgr"
+
   make
 }
 

--- a/llvm-amdgpu/.SRCINFO
+++ b/llvm-amdgpu/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = llvm-amdgpu
 	pkgdesc = Radeon Open Compute - LLVM toolchain (llvm, clang, lld)
 	pkgver = 3.3.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/llvm-project
 	arch = x86_64
 	license = custom:Apache 2.0 with LLVM Exception

--- a/llvm-amdgpu/PKGBUILD
+++ b/llvm-amdgpu/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=llvm-amdgpu
 pkgdesc='Radeon Open Compute - LLVM toolchain (llvm, clang, lld)'
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/llvm-project'
 license=('custom:Apache 2.0 with LLVM Exception')
@@ -27,12 +27,10 @@ build() {
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX='/opt/rocm/llvm' \
           -DLLVM_HOST_TRIPLE=$CHOST \
-          -DLLVM_BUILD_LLVM_DYLIB=ON \
           -DLLVM_BUILD_UTILS=ON \
           -DLLVM_ENABLE_BINDINGS=OFF \
           -DLLVM_ENABLE_OCAMLDOC=OFF \
           -DLLVM_ENABLE_PROJECTS='llvm;clang;lld' \
-          -DLLVM_LINK_LLVM_DYLIB=ON \
           -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
           -DOCAMLFIND=NO \
           "$_dirname/llvm"

--- a/rocm-opencl-runtime/.SRCINFO
+++ b/rocm-opencl-runtime/.SRCINFO
@@ -1,14 +1,13 @@
 pkgbase = rocm-opencl-runtime
 	pkgdesc = Radeon Open Compute - OpenCL runtime
 	pkgver = 3.3.0
-	pkgrel = 5
+	pkgrel = 6
 	url = https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime
 	arch = x86_64
 	license = MIT
 	makedepends = mesa
 	makedepends = cmake
 	makedepends = git
-	makedepends = llvm-roc
 	makedepends = rocm-cmake
 	depends = hsakmt-roct
 	depends = hsa-rocr

--- a/rocm-opencl-runtime/PKGBUILD
+++ b/rocm-opencl-runtime/PKGBUILD
@@ -5,13 +5,13 @@ _opencl_icd_loader_commit='978b4b3a29a3aebc86ce9315d5c5963e88722d03'
 
 pkgname=rocm-opencl-runtime
 pkgver=3.3.0
-pkgrel=5
+pkgrel=6
 pkgdesc='Radeon Open Compute - OpenCL runtime'
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime'
 license=('MIT')
 depends=('hsakmt-roct' 'hsa-rocr' 'opencl-icd-loader' 'comgr')
-makedepends=('mesa' 'cmake' 'git' 'llvm-roc' 'rocm-cmake')
+makedepends=('mesa' 'cmake' 'git' 'rocm-cmake')
 provides=("$pkgname" 'opencl-driver')
 source=("$url/archive/roc-$pkgver.tar.gz"
         "$_opencl_icd_loader_repo/archive/$_opencl_icd_loader_commit.tar.gz"


### PR DESCRIPTION
In order to have a working PyTorch, LLVM_DYLIB has to turn off (as by default and in AMD packages). If it is compiled and used for links, PyTorch would fail with:
```
:CommandLine Error: Option 'disable-symbolication' registered more than once!
  LLVM ERROR: inconsistency in registered CommandLine options
```
Moreover, this allows llvm-amdgpu to be used only to compile Comgr as describe by ROC team (llvm-amd is just a patched version of llvm and should not be necessary in the future).

This PR includes modification for llvm-amdgpu, comgr and also rocm-opencl-runtime which does not need custom llvm (maybe just the official one).
