### PR TITLE
Update miopen to 3.3.0

### DIFF
--- a/hcc/.SRCINFO
+++ b/hcc/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hcc
 	pkgdesc = HCC is an Open Source, Optimizing C++ Compiler for Heterogeneous Compute
 	pkgver = 3.3.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/hcc
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/hcc/PKGBUILD
+++ b/hcc/PKGBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Markus Näther <naetherm@cs.uni-freiburg.de>
 pkgname=hcc
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="HCC is an Open Source, Optimizing C++ Compiler for Heterogeneous Compute"
 arch=('x86_64')
 url="https://github.com/RadeonOpenCompute/hcc"
@@ -36,6 +36,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/opt/rocm/hcc \
         -DLLVM_INSTALL_UTILS=TRUE \
         "$srcdir/hcc-roc-hcc-$pkgver"
+
   make
 }
 
@@ -44,10 +45,10 @@ package() {
 
   make DESTDIR="$pkgdir" install
 
-  # add links
+  # add links (extractkernel is for rocblas with tensile)
   install -d "$pkgdir/usr/bin"
   local _fn
-  for _fn in hcc hcc-config; do
+  for _fn in hcc hcc-config extractkernel; do
     ln -s "/opt/rocm/hcc/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 

--- a/hip-hcc/.SRCINFO
+++ b/hip-hcc/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-hcc
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCm-Developer-Tools/HIP
 	arch = x86_64
 	license = MIT

--- a/hip-hcc/PKGBUILD
+++ b/hip-hcc/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-hcc
 pkgver=3.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/HIP"
@@ -28,6 +28,13 @@ package() {
   cd "$srcdir/build"
 
   make DESTDIR="$pkgdir" install
+
+  # add links (hipconfig is for rocblas with tensile)
+  install -d "$pkgdir/usr/bin"
+  local _fn
+  for _fn in hipcc hip-config; do
+    ln -s "/opt/rocm/hip/bin/$_fn" "$pkgdir/usr/bin/$_fn"
+  done
 
   install -d "$pkgdir/etc/ld.so.conf.d"
   cat << EOF > "$pkgdir/etc/ld.so.conf.d/hip.conf"

--- a/hip/.SRCINFO
+++ b/hip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.3.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCm-Developer-Tools/HIP
 	arch = x86_64
 	license = MIT

--- a/hip/PKGBUILD
+++ b/hip/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakub Okoński <jakub@okonski.org>
 pkgname=hip
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/HIP"
@@ -24,6 +24,7 @@ build() {
   cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip \
         "$srcdir/HIP-rocm-$pkgver"
+
   make
 }
 
@@ -31,6 +32,13 @@ package() {
   cd "$srcdir/build"
 
   make DESTDIR="$pkgdir" install
+
+  # add links (hipconfig is for rocblas with tensile)
+  install -d "$pkgdir/usr/bin"
+  local _fn
+  for _fn in hipcc hip-config; do
+    ln -s "/opt/rocm/hip/bin/$_fn" "$pkgdir/usr/bin/$_fn"
+  done
 
   install -d "$pkgdir/etc/ld.so.conf.d"
   cat << EOF > "$pkgdir/etc/ld.so.conf.d/hip.conf"

--- a/miopen/.SRCINFO
+++ b/miopen/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = miopen
 	pkgdesc = AMD's Machine Intelligence Library
-	pkgver = 2.3.0.2.2.1
-	pkgrel = 4
+	pkgver = 3.3.0
+	pkgrel = 1
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
 	license = custom:NCSAOSL
@@ -15,8 +15,8 @@ pkgbase = miopen
 	depends = rocblas
 	depends = boost>=1.58
 	depends = rocm-clang-ocl
-	source = https://github.com/ROCmSoftwarePlatform/MIOpen/archive/2.2.1.tar.gz
-	sha256sums = 445870318d7abb75a703b1021e8cb198bb64a5e1c9401487db40b5c3a7ae41e4
+	source = https://github.com/ROCmSoftwarePlatform/MIOpen/archive/roc-3.3.0.tar.gz
+	sha256sums = ab056f7921c2e4a7932225409b836258327f5ec5e3ee513726a114cd303d9b59
 
 pkgname = miopen
 

--- a/miopen/PKGBUILD
+++ b/miopen/PKGBUILD
@@ -1,17 +1,15 @@
 # Maintainer: Jakub Okoński <jakub@okonski.org>
 pkgname=miopen
-# upstream has different versioning, let's keep it at 2.3.0 until they catch up
-_pkgver=2.2.1
-pkgver=2.3.0.$_pkgver
-pkgrel=4
+pkgver=3.3.0
+pkgrel=1
 pkgdesc="AMD's Machine Intelligence Library"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
 license=('custom:NCSAOSL')
 depends=('ocl-icd' 'hip' 'hcc' 'rocblas' 'boost>=1.58' 'rocm-clang-ocl')
 makedepends=('opencl-headers' 'cmake' 'half' 'miopengemm')
-source=("https://github.com/ROCmSoftwarePlatform/MIOpen/archive/$_pkgver.tar.gz")
-sha256sums=('445870318d7abb75a703b1021e8cb198bb64a5e1c9401487db40b5c3a7ae41e4')
+source=("https://github.com/ROCmSoftwarePlatform/MIOpen/archive/roc-$pkgver.tar.gz")
+sha256sums=('ab056f7921c2e4a7932225409b836258327f5ec5e3ee513726a114cd303d9b59')
 
 build() {
   mkdir -p "$srcdir/build"
@@ -26,7 +24,9 @@ build() {
         -DMIOPEN_BACKEND=HIP \
         -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" \
         -DHALF_INCLUDE_DIR=/usr/include/half \
-        "$srcdir/MIOpen-$_pkgver"
+        -DBoost_NO_BOOST_CMAKE=ON \
+        "$srcdir/MIOpen-roc-$pkgver"
+
   make
 }
 

--- a/rocblas/.SRCINFO
+++ b/rocblas/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = rocblas
 	pkgdesc = Next generation BLAS implementation for ROCm platform
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCmSoftwarePlatform/rocBLAS
 	arch = x86_64
 	license = custom:NCSAOSL
 	makedepends = cmake
 	makedepends = hcc>=3.3.0
-	makedepends = python2
+	makedepends = python
 	makedepends = boost
 	makedepends = comgr>=3.3.0
 	makedepends = rocminfo

--- a/rocblas/PKGBUILD
+++ b/rocblas/PKGBUILD
@@ -2,13 +2,13 @@
 pkgname=rocblas
 _pkgver=3.3.0
 pkgver="$_pkgver"
-pkgrel=2
+pkgrel=3
 pkgdesc="Next generation BLAS implementation for ROCm platform"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/rocBLAS"
 license=('custom:NCSAOSL')
 depends=('hcc' 'hip')
-makedepends=('cmake' "hcc>=$pkgver" 'python2' 'boost' "comgr>=$pkgver" 'rocminfo' 'hsa-ext-rocr')
+makedepends=('cmake' "hcc>=$pkgver" 'python' 'boost' "comgr>=$pkgver" 'rocminfo' 'hsa-ext-rocr')
 source=("https://github.com/ROCmSoftwarePlatform/rocBLAS/archive/rocm-$_pkgver.tar.gz")
 sha256sums=('aaa8f0479202bdbe94d2ec5655a76055656f743b0d36816501cb84a533084034')
 
@@ -30,8 +30,12 @@ build() {
         -HIP_DIR=/opt/rocm/hip/lib/cmake/hip \
         -hcc_DIR=/opt/rocm/hcc/lib/cmake/hcc \
         -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
-        -DBUILD_WITH_TENSILE=OFF \
         "$srcdir/rocBLAS-rocm-$_pkgver"
+
+  # Fix for latest llvm
+  sed -i 's/Impl::inputOne(io, key, \*value)/Impl::inputOne(io, key.str(), \*value)/g' \
+    $srcdir/build/virtualenv/lib/python*/site-packages/Tensile/Source/lib/include/Tensile/llvm/YAML.hpp
+
   make
 }
 


### PR DESCRIPTION
This PR includes what is needed to build MIOpen 3.3.0.

In order to update miopen to 3.3.0, rocblas should be build with tensile on (it is by default), see  https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/991. Moreover, a CMAKE option should be add to workaround an update of boost.

To build rocblas with tensile, we need symlinks for extractkernel & hipconfig in PATH directory and a micro-patch for rocblas.

BTW, it seems that tensile need a lot of ram (or swap actually) to build all "kernels".