### PR TITLE
add symlink in /opt/rocm/include for sub-project

### DIFF
--- a/rccl/.SRCINFO
+++ b/rccl/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rccl
 	pkgdesc = ROCm Communication Collectives Library
 	pkgver = 3.3.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCmSoftwarePlatform/rccl
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/rccl/PKGBUILD
+++ b/rccl/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Markus Näther <naetherm@informatik.uni-freiburg.de>
 pkgname=rccl
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROCm Communication Collectives Library"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/rccl"
@@ -28,6 +28,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/opt/rocm/rccl \
         -DBUILD_TESTS=OFF \
         "$srcdir/rccl-rocm-$pkgver"
+
   make
 }
 
@@ -35,6 +36,9 @@ package() {
   cd "$srcdir/build"
 
   make DESTDIR="$pkgdir" install
+
+  install -d "$pkgdir/opt/rocm/include"
+  ln -s /opt/rocm/rccl/include/rccl.h "$pkgdir/opt/rocm/include"
 
   install -d "$pkgdir/etc/ld.so.conf.d"
   cat << EOF > "$pkgdir/etc/ld.so.conf.d/rccl.conf"

--- a/rocthrust/.SRCINFO
+++ b/rocthrust/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocthrust
 	pkgdesc = Port of the Thrust parallel algorithm library atop HIP/ROCm.
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCmSoftwarePlatform/rocThrust
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/rocthrust/PKGBUILD
+++ b/rocthrust/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Markus Näther <naetherm@informatik.uni-freiburg.de>
 pkgname=rocthrust
 pkgver=3.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Port of the Thrust parallel algorithm library atop HIP/ROCm."
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/rocThrust"
@@ -45,4 +45,7 @@ package() {
   cat << EOF > "$pkgdir/etc/ld.so.conf.d/rocthrust.conf"
 /opt/rocm/rocthrust/lib
 EOF
+
+  install -d "$pkgdir/opt/rocm/include"
+  ln -s /opt/rocm/rocthrust/include/thrust "$pkgdir/opt/rocm/include"
 }


### PR DESCRIPTION
In order to build PyTorch, I had to add some symlink in /opt/rocm/include. It seems to be done for each subproject in ubuntu packages so maybe it should be done for other sub-projects.