### PR TITLE
hip/hip-hcc: fix typo hip-config -> hipconfig

### DIFF
--- a/hip-hcc/.SRCINFO
+++ b/hip-hcc/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-hcc
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.3.0
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/ROCm-Developer-Tools/HIP
 	arch = x86_64
 	license = MIT

--- a/hip-hcc/PKGBUILD
+++ b/hip-hcc/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-hcc
 pkgver=3.3.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/HIP"
@@ -32,7 +32,7 @@ package() {
   # add links (hipconfig is for rocblas with tensile)
   install -d "$pkgdir/usr/bin"
   local _fn
-  for _fn in hipcc hip-config; do
+  for _fn in hipcc hipconfig; do
     ln -s "/opt/rocm/hip/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 

--- a/hip/.SRCINFO
+++ b/hip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCm-Developer-Tools/HIP
 	arch = x86_64
 	license = MIT

--- a/hip/PKGBUILD
+++ b/hip/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakub Okoński <jakub@okonski.org>
 pkgname=hip
 pkgver=3.3.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url="https://github.com/ROCm-Developer-Tools/HIP"
@@ -36,7 +36,7 @@ package() {
   # add links (hipconfig is for rocblas with tensile)
   install -d "$pkgdir/usr/bin"
   local _fn
-  for _fn in hipcc hip-config; do
+  for _fn in hipcc hipconfig; do
     ln -s "/opt/rocm/hip/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 


### PR DESCRIPTION
Fix a stupid typo for both hip and hip-hcc where hipconfig was written as hip-config.