### PR TITLE
[hcc] Fix package description and remove CMAKE_BUILD_TYPE

### DIFF
--- a/hcc-git/.SRCINFO
+++ b/hcc-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hcc-git
 	pkgdesc = C++ Compiler for Heterogeneous Compute
 	pkgver = latest
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/hcc
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/hcc-git/PKGBUILD
+++ b/hcc-git/PKGBUILD
@@ -2,7 +2,7 @@
 _pkgname=hcc
 pkgname="$_pkgname-git"
 pkgver=latest
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ Compiler for Heterogeneous Compute"
 arch=('x86_64')
 url="https://github.com/RadeonOpenCompute/hcc"
@@ -35,8 +35,7 @@ build() {
   mkdir -p "$srcdir/build"
   cd "$srcdir/build"
 
-  cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm/hcc \
+  cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/hcc \
         -DLLVM_INSTALL_UTILS=TRUE \
         "$srcdir/$_pkgname"
   make

--- a/hcc/.SRCINFO
+++ b/hcc/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hcc
-	pkgdesc = HCC is an Open Source, Optimizing C++ Compiler for Heterogeneous Compute
+	pkgdesc = C++ Compiler for Heterogeneous Compute
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/hcc
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/hcc/PKGBUILD
+++ b/hcc/PKGBUILD
@@ -4,8 +4,8 @@
 # Maintainer: Markus Näther <naetherm@cs.uni-freiburg.de>
 pkgname=hcc
 pkgver=3.3.0
-pkgrel=2
-pkgdesc="HCC is an Open Source, Optimizing C++ Compiler for Heterogeneous Compute"
+pkgrel=3
+pkgdesc='C++ Compiler for Heterogeneous Compute'
 arch=('x86_64')
 url="https://github.com/RadeonOpenCompute/hcc"
 license=('custom:NCSAOSL')
@@ -32,8 +32,7 @@ build() {
   mkdir -p "$srcdir/build"
   cd "$srcdir/build"
 
-  cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm/hcc \
+  cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/hcc \
         -DLLVM_INSTALL_UTILS=TRUE \
         "$srcdir/hcc-roc-hcc-$pkgver"
 


### PR DESCRIPTION
The package description for HCC is too long which breaks the syntax highlighting in vim.