### PR TITLE
Add some binary packages from ubuntu deb

### DIFF
--- a/comgr-bin/.SRCINFO
+++ b/comgr-bin/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = comgr-bin
+	pkgdesc = Library to provide support functions
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/ROCm-CompilerSupport
+	arch = x86_64
+	license = custom:NCSAOSL
+	depends = libtinfo5
+	provides = comgr
+	conflicts = comgr
+	source = http://repo.radeon.com/rocm/apt/3.3/pool/main/c/comgr/comgr_1.6.0.124-rocm-rel-3.3-19-7ac2e34_amd64.deb
+	sha256sums = 8d8f46493769594dcde98e57ce7d7ab4f7921fe84794a9debe531310d290fcdf
+
+pkgname = comgr-bin

--- a/comgr-bin/PKGBUILD
+++ b/comgr-bin/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=comgr-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='Library to provide support functions'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/ROCm-CompilerSupport'
+license=('custom:NCSAOSL')
+depends=('libtinfo5')
+provides=('comgr')
+conflicts=('comgr')
+_debfile='comgr_1.6.0.124-rocm-rel-3.3-19-7ac2e34_amd64.deb'
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/c/comgr/$_debfile")
+sha256sums=('8d8f46493769594dcde98e57ce7d7ab4f7921fe84794a9debe531310d290fcdf')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}

--- a/hcc-bin/.SRCINFO
+++ b/hcc-bin/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = hcc-bin
+	pkgdesc = HCC: An Open Source, Optimizing C++ Compiler for Heterogeneous Compute
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/hcc
+	arch = x86_64
+	license = EULA
+	depends = hsa-rocr
+	depends = libtinfo5
+	provides = hcc
+	conflicts = hcc
+	source = http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hcc/hcc_3.1.20114_amd64.deb
+	sha256sums = 76b10fe9f11a7ba892db31d6313fb83a62fe2054f1c9cdab6fc1323c9c9cd639
+
+pkgname = hcc-bin

--- a/hcc-bin/PKGBUILD
+++ b/hcc-bin/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=hcc-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='HCC: An Open Source, Optimizing C++ Compiler for Heterogeneous Compute'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/hcc'
+license=('EULA')
+depends=('hsa-rocr' 'libtinfo5')
+provides=('hcc')
+conflicts=('hcc')
+_debfile='hcc_3.1.20114_amd64.deb'
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hcc/$_debfile")
+sha256sums=('76b10fe9f11a7ba892db31d6313fb83a62fe2054f1c9cdab6fc1323c9c9cd639')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}

--- a/hip-base-bin/.SRCINFO
+++ b/hip-base-bin/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = hip-base-bin
+	pkgdesc = HIP: Heterogenous-computing Interface for Portability [BASE]
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/HIP
+	arch = x86_64
+	license = EULA
+	depends = perl
+	provides = hip-base
+	conflicts = hip-hcc
+	conflicts = hip-nvcc
+	source = http://repo.radeon.com/rocm/apt/debian/pool/main/h/hip-base/hip-base_3.3.20126.4629-rocm-rel-3.3-19-2dbba46b_amd64.deb
+	sha256sums = SKIP
+
+pkgname = hip-base-bin

--- a/hip-base-bin/PKGBUILD
+++ b/hip-base-bin/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=hip-base-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='HIP: Heterogenous-computing Interface for Portability [BASE]'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/HIP'
+license=('EULA')
+depends=('perl')
+provides=('hip-base')
+conflicts=('hip-hcc' 'hip-nvcc')
+_debfile='hip-base_3.3.20126.4629-rocm-rel-3.3-19-2dbba46b_amd64.deb'
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hip-base/$_debfile")
+sha256sums=('3de86c1df5761e85c4009b42aeef3bb4318cba1caecf5f069200d1b19a06b155')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}

--- a/hip-hcc-bin/.SRCINFO
+++ b/hip-hcc-bin/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = hip-hcc-bin
+	pkgdesc = HIP: Heterogenous-computing Interface for Portability [HCC]
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/HIP
+	arch = x86_64
+	license = EULA
+	depends = hcc
+	depends = hip-base
+	depends = comgr
+	depends = rocminfo
+	provides = hip
+	conflicts = hip-hcc
+	source = http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hip-hcc/hip-hcc_3.3.20126.4629-rocm-rel-3.3-19-2dbba46b_amd64.deb
+	sha256sums = 8234e2d8d1f6159fb35f3a99e354beeb40d6eda2a603c4e091ab706ea8d4ec08
+
+pkgname = hip-hcc-bin

--- a/hip-hcc-bin/PKGBUILD
+++ b/hip-hcc-bin/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=hip-hcc-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='HIP: Heterogenous-computing Interface for Portability [HCC]'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/HIP'
+license=('EULA')
+depends=('hcc' 'hip-base' 'comgr' 'rocminfo')
+provides=('hip')
+conflicts=('hip-hcc')
+_debfile='hip-hcc_3.3.20126.4629-rocm-rel-3.3-19-2dbba46b_amd64.deb'
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hip-hcc/$_debfile")
+sha256sums=('8234e2d8d1f6159fb35f3a99e354beeb40d6eda2a603c4e091ab706ea8d4ec08')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}

--- a/hsa-ext-rocr/.SRCINFO
+++ b/hsa-ext-rocr/.SRCINFO
@@ -1,12 +1,13 @@
 pkgbase = hsa-ext-rocr
 	pkgdesc = ROCm Platform Runtime: Closed source components
 	pkgver = 3.3.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/ROCR-Runtime
 	arch = x86_64
 	license = EULA
 	depends = hsa-rocr
 	depends = hsakmt-roct
+	options = !strip
 	source = http://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/hsa-ext-rocr-dev_1.1.30300.0-rocm-rel-3.3-19-23fc088b_amd64.deb
 	sha256sums = 6b44e286b395d946b865ec1f3cc546356396785ac1fde591d07af02d0aa7c25d
 

--- a/hsa-ext-rocr/PKGBUILD
+++ b/hsa-ext-rocr/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=hsa-ext-rocr
 pkgver=3.3.0
-pkgrel=2
+pkgrel=3
 _debfile=hsa-ext-rocr-dev_1.1.30300.0-rocm-rel-3.3-19-23fc088b_amd64.deb
 pkgdesc='ROCm Platform Runtime: Closed source components'
 arch=('x86_64')
@@ -13,6 +13,7 @@ license=('EULA')
 depends=("hsa-rocr" "hsakmt-roct")
 source=("http://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/$_debfile")
 sha256sums=('6b44e286b395d946b865ec1f3cc546356396785ac1fde591d07af02d0aa7c25d')
+options=('!strip')
 
 package() {
   tar -C "$pkgdir" -xf data.tar.gz

--- a/hsa-rocr-dev-bin/.SRCINFO
+++ b/hsa-rocr-dev-bin/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = hsa-rocr-dev-bin
+	pkgdesc = AMD Heterogeneous System Architecture HSA - Linux HSA Runtime for Boltz mann (ROCm) platforms
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/ROCR-Runtime
+	arch = x86_64
+	license = custom:NCSAOSL
+	depends = hsakmt-roct
+	provides = rocr-runtime
+	provides = hsa-rocr
+	conflicts = hsa-rocr
+	source = http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hsa-rocr-dev/hsa-rocr-dev_1.1.30300.0-rocm-rel-3.3-19-23fc088b_amd64.deb
+	sha256sums = 862d1bdd3cafd2aac0c3734a7f05fd44d328c0d9217b969f905bbcd2d6980f65
+
+pkgname = hsa-rocr-dev-bin

--- a/hsa-rocr-dev-bin/PKGBUILD
+++ b/hsa-rocr-dev-bin/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=hsa-rocr-dev-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='AMD Heterogeneous System Architecture HSA - Linux HSA Runtime for Boltz
+mann (ROCm) platforms'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/ROCR-Runtime'
+license=('custom:NCSAOSL')
+depends=('hsakmt-roct')
+provides=('rocr-runtime' 'hsa-rocr')
+conflicts=('hsa-rocr')
+_debfile='hsa-rocr-dev_1.1.30300.0-rocm-rel-3.3-19-23fc088b_amd64.deb'
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hsa-rocr-dev/$_debfile")
+sha256sums=('862d1bdd3cafd2aac0c3734a7f05fd44d328c0d9217b969f905bbcd2d6980f65')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}

--- a/hsakmt-roct-bin/.SRCINFO
+++ b/hsakmt-roct-bin/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = hsakmt-roct-bin
+	pkgdesc = HSAKMT library for AMD KFD support
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface
+	arch = x86_64
+	license = custom:NCSAOSL
+	depends = glibc
+	depends = numactl
+	depends = pciutils
+	depends = zlib
+	depends = systemd-libs
+	provides = hsakmt-roct
+	provides = roct-thunk-interface
+	conflicts = hsakmt-roct
+	source = http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hsakmt-roct/hsakmt-roct_1.0.9-330-gd84bc09_amd64.deb
+	sha256sums = 35903d3f31807b4a540ae437907d8aa337e170efbf64af3653ca3ffb8cc84881
+
+pkgname = hsakmt-roct-bin

--- a/hsakmt-roct-bin/PKGBUILD
+++ b/hsakmt-roct-bin/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=hsakmt-roct-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='HSAKMT library for AMD KFD support'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface'
+license=('custom:NCSAOSL')
+depends=('glibc' 'numactl' 'pciutils' 'zlib' 'systemd-libs')
+provides=('hsakmt-roct' 'roct-thunk-interface')
+conflicts=('hsakmt-roct')
+_debfile='hsakmt-roct_1.0.9-330-gd84bc09_amd64.deb'
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/h/hsakmt-roct/$_debfile")
+sha256sums=(35903d3f31807b4a540ae437907d8aa337e170efbf64af3653ca3ffb8cc84881)
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+  install -Dm644 /dev/stdin "$pkgdir/etc/ld.so.conf.d/$pkgname.conf" <<-EOF
+    /opt/rocm/lib
+EOF
+}

--- a/libtinfo5-bin/.SRCINFO
+++ b/libtinfo5-bin/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = libtinfo5-bin
+	pkgdesc = Shared low-level terminfo library for terminal handling
+	pkgver = 6.1
+	pkgrel = 1
+	url = https://invisible-island.net/ncurses
+	arch = x86_64
+	license = GPL
+	depends = glibc
+	provides = libtinfo5
+	options = !strip
+	source = http://archive.ubuntu.com/ubuntu/pool/main/n/ncurses/libtinfo5_6.1-1ubuntu1.18.04_amd64.deb
+	sha256sums = bb4d4d80720149692ea0d5bca1a5dac57737afe447810ce69dd4a95107121da5
+
+pkgname = libtinfo5-bin

--- a/libtinfo5-bin/PKGBUILD
+++ b/libtinfo5-bin/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=libtinfo5-bin
+pkgver=6.1
+pkgrel=1
+pkgdesc='Shared low-level terminfo library for terminal handling'
+arch=('x86_64')
+url='https://invisible-island.net/ncurses'
+license=('GPL')
+depends=('glibc')
+provides=('libtinfo5')
+_debfile='libtinfo5_6.1-1ubuntu1.18.04_amd64.deb'
+source=("http://archive.ubuntu.com/ubuntu/pool/main/n/ncurses/$_debfile")
+sha256sums=('bb4d4d80720149692ea0d5bca1a5dac57737afe447810ce69dd4a95107121da5')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.xz
+  mv "$pkgdir/lib/x86_64-linux-gnu/"*.so.* "$pkgdir/usr/lib"
+  rmdir "$pkgdir/lib/x86_64-linux-gnu" "$pkgdir/lib"
+  mv "$pkgdir/usr/lib/x86_64-linux-gnu/"*.so.* "$pkgdir/usr/lib"
+  rmdir "$pkgdir/usr/lib/x86_64-linux-gnu"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}

--- a/rocminfo-bin/.SRCINFO
+++ b/rocminfo-bin/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = rocminfo-bin
+	pkgdesc = Radeon Open Compute (ROCm) Runtime rocminfo tool
+	pkgver = 3.3.0
+	pkgrel = 1
+	url = https://github.com/RadeonOpenCompute/rocminfo
+	arch = x86_64
+	license = custom:NCSAOSL
+	depends = pciutils
+	depends = python
+	depends = hsa-rocr
+	provides = rocminfo
+	conflicts = rocminfo
+	source = http://repo.radeon.com/rocm/apt/3.3/pool/main/r/rocminfo/rocminfo_1.30300.0_amd64.deb
+	sha256sums = e0ec286df8993c4e57451e438dc1a9bb96fefef834e326c2bd54b9d501d6f1c3
+
+pkgname = rocminfo-bin

--- a/rocminfo-bin/PKGBUILD
+++ b/rocminfo-bin/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: Samuel Bernard <samuel.bernard@gmail.com>
+
+pkgname=rocminfo-bin
+pkgver=3.3.0
+pkgrel=1
+pkgdesc='Radeon Open Compute (ROCm) Runtime rocminfo tool'
+arch=('x86_64')
+url='https://github.com/RadeonOpenCompute/rocminfo'
+license=('custom:NCSAOSL')
+depends=('pciutils' 'python' 'hsa-rocr')
+provides=('rocminfo')
+conflicts=('rocminfo')
+_debfile='rocminfo_1.30300.0_amd64.deb'
+noextract=($_debfile2)
+source=("http://repo.radeon.com/rocm/apt/3.3/pool/main/r/rocminfo/$_debfile")
+sha256sums=('e0ec286df8993c4e57451e438dc1a9bb96fefef834e326c2bd54b9d501d6f1c3')
+options=('!strip')
+
+package() {
+  tar -C "$pkgdir" -xf data.tar.gz
+  rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
+  find "$pkgdir" -type d -exec chmod 755 '{}' '+'
+}


### PR DESCRIPTION
Everything to get up to hip-hcc from ubuntu package. Unfortunately HIP don’t work on Arch, probably because of glibc version.
I’m waiting an official ubuntu 20.04 support to test again (same glibc version) and package the rest.

Not striping is required for all lib that may contain GPU code which seems to be unused but actually are.