### PR TITLE
[rocm-opencl-runtime] Cherry-pick fix for multiple "ret_val" definitions

### DIFF
--- a/rocm-opencl-runtime/PKGBUILD
+++ b/rocm-opencl-runtime/PKGBUILD
@@ -14,20 +14,26 @@ depends=('hsakmt-roct' 'hsa-rocr' 'opencl-icd-loader' 'comgr')
 makedepends=('mesa' 'cmake' 'git' 'rocm-cmake')
 provides=("$pkgname" 'opencl-driver')
 source=("$url/archive/roc-$pkgver.tar.gz"
-        "$_opencl_icd_loader_repo/archive/$_opencl_icd_loader_commit.tar.gz"
-        'install_vendor_file.patch')
+        "git+${_opencl_icd_loader_repo}.git"
+        "install_vendor_file.patch")
 sha256sums=('ac6999f1a491ab066286c2bd6adf50f08f831286f56e267879f9f7eced22f98e'
-            '0c14bf890bd198ef5a814b5b7ed57b69e890b0c0a1bcfba8fdad996fa1a97fc7'
+            'SKIP'
             'b83de5ea8ae889664ce2725f90c5db8c1c9e98839d75c7743b355d16435dccee')
 _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
-_opencl_dirname="$(basename "$_opencl_icd_loader_repo")-$(basename "${source[1]}" .tar.gz)"
+_opencl_dirname="$(basename "$_opencl_icd_loader_repo")"
 
 prepare() {
     cd "$_dirname"
     patch -Np1 -i "$srcdir/install_vendor_file.patch"
 
     mkdir -p api/opencl/khronos
-    mv "$srcdir/$_opencl_dirname" api/opencl/khronos/icd
+    cd api/opencl/khronos
+    mv "$srcdir/$_opencl_dirname" icd
+    cd icd
+    git checkout $_opencl_icd_loader_commit
+    # fix ret_val definitions
+    # see: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/113
+    git cherry-pick -n "9acc3fcbeadeef27c57d9fb195c4a94fbcf52f66"
 }
 
 build() {


### PR DESCRIPTION
Cherry-pick a fix from Khronos ICD loader upstream. See: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/113

Fixes #165. I know this might not be a super clean way to do it, so revision would be appreciated. :)