### PR TITLE
[rock-dkms-firmware-bin] New package from 3.5

### DIFF
--- a/rock-dkms-firmware-bin/.SRCINFO
+++ b/rock-dkms-firmware-bin/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = rock-dkms-firmware-bin
+	pkgdesc = Linux AMD GPU firmware from ROC in DKMS format.
+	pkgver = 3.5
+	pkgrel = 2
+	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
+	arch = any
+	license = GPL
+	depends = dkms
+	provides = rock-dkms-firmware
+	conflicts = rock-dkms-firmware
+	options = !strip
+	options = !emptydirs
+	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_3.5-30_all.deb
+	sha256sums = 1777f6b321800f9c0727322c2e5151634fae572889b5c27dfc71549894a4f291
+
+pkgname = rock-dkms-firmware-bin
+

--- a/rock-dkms-firmware-bin/.SRCINFO
+++ b/rock-dkms-firmware-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-firmware-bin
 	pkgdesc = Linux AMD GPU firmware from ROC in DKMS format.
 	pkgver = 3.5
-	pkgrel = 2
+	pkgrel = 1
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL

--- a/rock-dkms-firmware-bin/PKGBUILD
+++ b/rock-dkms-firmware-bin/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=rock-dkms-firmware-bin
 pkgver=3.5
 _pkgver=$pkgver-30
-pkgrel=2
+pkgrel=1
 pkgdesc="Linux AMD GPU firmware from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"

--- a/rock-dkms-firmware-bin/PKGBUILD
+++ b/rock-dkms-firmware-bin/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: acxz <akashpatel2008@yahoo.com>
+pkgname=rock-dkms-firmware-bin
+pkgver=3.5
+_pkgver=$pkgver-30
+pkgrel=2
+pkgdesc="Linux AMD GPU firmware from ROC in DKMS format."
+arch=('any')
+url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"
+license=('GPL')
+depends=('dkms')
+provides=('rock-dkms-firmware')
+conflicts=('rock-dkms-firmware')
+options=('!strip' '!emptydirs')
+source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_${_pkgver}_all.deb")
+
+sha256sums=('1777f6b321800f9c0727322c2e5151634fae572889b5c27dfc71549894a4f291')
+
+package() {
+  cd "$srcdir"
+
+  tar xf data.tar.xz -C "$pkgdir"
+  install -Dm644 "$pkgdir/usr/share/doc/rock-dkms-firmware/copyright" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
ROCk-dkms split firmware into a different package. I can only find this binary release, but I guess that typical with firmware.

This is just a simple modification from the rock-dkms-bin package.

This package installs fine, but rock-dkms-bin doesn't on neither "5.6.15-1" or "4.19.125-1" (Manjaro), complaining about the missing `DRM_VER`.

P.S. I think the ROCk firmware is necessary for device support for OpenCL 2.2, but I'm not sure.