### PR TITLE
[rock-dkms-bin] Fix DRM_VER in dkms Makefile

### DIFF
--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -13,7 +13,9 @@ pkgbase = rock-dkms-bin
 	options = !emptydirs
 	backup = etc/modprobe.d/blacklist-radeon.conf
 	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_3.5-30_all.deb
+	source = rock_compatibility.patch::https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch
 	sha256sums = f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece
+	sha256sums = e2afe9cd25934ebe32d9fec06e534b173b999bb0caf102f9a2a204f8b5c08b86
 
 pkgname = rock-dkms-bin
 

--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-bin
 	pkgdesc = Linux AMD GPU kernel driver from ROC in DKMS format.
 	pkgver = 3.5
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL

--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -15,7 +15,7 @@ pkgbase = rock-dkms-bin
 	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_3.5-30_all.deb
 	source = rock_compatibility.patch::https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch
 	sha256sums = f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece
-	sha256sums = e2afe9cd25934ebe32d9fec06e534b173b999bb0caf102f9a2a204f8b5c08b86
+	sha256sums = a8dec1dc7d118844dfe2bbf4beab8b15b69cdae478957dfc5e033997f58d00cb
 
 pkgname = rock-dkms-bin
 

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -12,17 +12,23 @@ provides=('rock-dkms')
 conflicts=('rock-dkms')
 backup=('etc/modprobe.d/blacklist-radeon.conf')
 options=('!strip' '!emptydirs')
-source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb")
+source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb"
+        "rock_compatibility.patch"::"https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch")
 
-sha256sums=('f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece')
+sha256sums=('f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece'
+            'e2afe9cd25934ebe32d9fec06e534b173b999bb0caf102f9a2a204f8b5c08b86')
 
 package() {
   cd "$srcdir"
 
   tar xf data.tar.xz -C "$pkgdir"
 
-  sed -i "28iDRM_VER=\$\(shell sed -n 's/^VERSION = \\\(.*\\\)/\\\1/p' \$(kdir)/Makefile)\nDRM_PATCH=\$(shell sed -n 's/^PATCHLEVEL = \\\(.*\\\)/\\\1/p' \$(kdir)/Makefile)\n" \
-    ${pkgdir}/usr/src/amdgpu-${_pkgver}/amd/dkms/Makefile
+  filterdiff -i "*Makefile" rock_compatibility.patch > Makefile.patch
+  filterdiff -i "*amdgpu_bios.c" rock_compatibility.patch > amdgpu_bios.c.patch
+
+  cd $pkgdir/usr/src/amdgpu-${_pkgver}/amd
+  patch --forward --strip=4 dkms/Makefile --input=${srcdir}/Makefile.patch
+  patch --forward --strip=4 amdgpu/amdgpu_bios.c --input=${srcdir}/amdgpu_bios.c.patch
 
   install -Dm644 "$pkgdir/usr/share/doc/rock-dkms/copyright" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=rock-dkms-bin
 pkgver=3.5
 _pkgver=$pkgver-30
-pkgrel=2
+pkgrel=3
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"
@@ -20,5 +20,9 @@ package() {
   cd "$srcdir"
 
   tar xf data.tar.xz -C "$pkgdir"
+
+  sed -i "28iDRM_VER=\$\(shell sed -n 's/^VERSION = \\\(.*\\\)/\\\1/p' \$(kdir)/Makefile)\nDRM_PATCH=\$(shell sed -n 's/^PATCHLEVEL = \\\(.*\\\)/\\\1/p' \$(kdir)/Makefile)\n" \
+    ${pkgdir}/usr/src/amdgpu-${_pkgver}/amd/dkms/Makefile
+
   install -Dm644 "$pkgdir/usr/share/doc/rock-dkms/copyright" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -16,19 +16,21 @@ source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_
         "rock_compatibility.patch"::"https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch")
 
 sha256sums=('f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece'
-            'e2afe9cd25934ebe32d9fec06e534b173b999bb0caf102f9a2a204f8b5c08b86')
+            'a8dec1dc7d118844dfe2bbf4beab8b15b69cdae478957dfc5e033997f58d00cb')
 
 package() {
   cd "$srcdir"
 
   tar xf data.tar.xz -C "$pkgdir"
 
-  filterdiff -i "*Makefile" rock_compatibility.patch > Makefile.patch
-  filterdiff -i "*amdgpu_bios.c" rock_compatibility.patch > amdgpu_bios.c.patch
+  head -n 37 rock_compatibility.patch > Makefile.patch
+  grep "amdgpu_bios.c b" rock_compatibility.patch -A 52 > amdgpu_bios.c.patch
+  tail -n 104 rock_compatibility.patch > amdkcl_kallsyms.patch
 
   cd $pkgdir/usr/src/amdgpu-${_pkgver}/amd
-  patch --forward --strip=4 dkms/Makefile --input=${srcdir}/Makefile.patch
-  patch --forward --strip=4 amdgpu/amdgpu_bios.c --input=${srcdir}/amdgpu_bios.c.patch
+  patch --forward -p4 dkms/Makefile --input=${srcdir}/Makefile.patch
+  patch --forward -p4 amdgpu/amdgpu_bios.c --input=${srcdir}/amdgpu_bios.c.patch
+  patch --forward -p5 --input=${srcdir}/amdkcl_kallsyms.patch
 
   install -Dm644 "$pkgdir/usr/share/doc/rock-dkms/copyright" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
`DRM_VER` will only be defined for a hardcoded selection of OS names. Arch (and Manjaro) is not in that list, so the dkms compilation will fail.

This change patches the makefile to provide a default, which assumes same conditions as under some other OS names. That condition being that `$(kdir)` is defined and that it contains a Makefile with `VERSION` and `PATCHLEVEL`

This compiles successfully with 4.19 and 5.6 but not 5.7
(Because [pci_platform_rom was removed in 5.7](https://github.com/torvalds/linux/commit/86845e37aca4c80eace290a727a49caa8390febb) )

5.6 boots normally with the module installed, but I'm not sure how to check if it was actually loaded, or if it's still using the one in the kernel?

P.S. Unfortunately clinfo still reports opencl 2.0 (with rocm-opencl-runtime) so, unless the rock module didn't actually load, this wasn't the solution to that problem...

## Related issue:
[ROCK-Kernel-Driver#94](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/issues/94)