### PR TITLE
[atmi] Update dependencies, builds in clean chroot

### DIFF
--- a/atmi/.SRCINFO
+++ b/atmi/.SRCINFO
@@ -1,13 +1,14 @@
 pkgbase = atmi
-	pkgdesc = Asynchronous Task and Memory Interface (ATMI) is a task graph framework for heterogeneous CPU-GPU systems.
+	pkgdesc = Task graph framework for heterogeneous CPU-GPU systems.
 	pkgver = 3.5.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/atmi
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
-	depends = rocm-cmake
-	depends = rocm-device-libs
+	makedepends = rsync
+	depends = hsa-rocr
+	depends = comgr
 	source = atmi-3.5.0.tar.gz::https://github.com/RadeonOpenCompute/atmi/archive/rocm-3.5.0.tar.gz
 	sha256sums = 3fb57d2e583fab82bd0582d0c2bccff059ca91122c18ac49a7770a8bb041a37b
 

--- a/atmi/PKGBUILD
+++ b/atmi/PKGBUILD
@@ -1,27 +1,27 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=atmi
 pkgver=3.5.0
-pkgrel=1
-pkgdesc="Asynchronous Task and Memory Interface (ATMI) is a task graph framework for heterogeneous CPU-GPU systems."
+pkgrel=2
+pkgdesc='Task graph framework for heterogeneous CPU-GPU systems.'
 arch=('x86_64')
 url="https://github.com/RadeonOpenCompute/atmi"
 license=('MIT')
-depends=('rocm-cmake' 'rocm-device-libs')
-makedepends=('cmake')
+depends=('hsa-rocr' 'comgr')
+makedepends=('cmake' 'rsync')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/RadeonOpenCompute/atmi/archive/rocm-$pkgver.tar.gz")
 sha256sums=('3fb57d2e583fab82bd0582d0c2bccff059ca91122c18ac49a7770a8bb041a37b')
+_dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
 
 build() {
-  mkdir -p "$srcdir/build"
-  cd "$srcdir/build"
-
-  cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/atmi \
-        "$srcdir/atmi-rocm-$pkgver/src"
-  make
+  cmake -B build -Wno-dev \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm/atmi \
+        -DROCM_VERSION="$pkgver" \
+        "$_dirname/src"
+  make -C build
 }
 
 package() {
-  cd "$srcdir/build"
+  DESTDIR="$pkgdir" make -C build install
 
-  make DESTDIR="$pkgdir" install
+  install -Dm644 "$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
Shorten package description, update dependencies, add option ROCM_VERSION to `cmake`. Otherwise the package does not build. Install MIT license file. The package now builds successfully in a clean chroot.