### PR TITLE
Create sync-to-aur.yml

### DIFF
--- a/.github/workflows/sync-to-aur.yml
+++ b/.github/workflows/sync-to-aur.yml
@@ -12,9 +12,9 @@ jobs:
         run: |
           echo ${{ secrets.AUR_SSH_KEY }} | install -Dm400 /dev/stdin ~/.ssh/id_ed25519
 
-      - name: Install and configure git
+      - name: Install packages
         run: |
-          sudo apt-get install git
+          sudo apt-get install git rsync
 
       - uses: actions/checkout@v2
         with:
@@ -23,20 +23,25 @@ jobs:
       - name: Sync packages to AUR
         run: |
           set -x
+
+          name=$(git show -s --format='%an')
+          email=$(git show -s --format='%ae')
+          message=$(git show -s --format='%s')
+
           for i in $(git show --pretty="" --name-only | cut -d/ -f1 | sort -u)
           do
             [ ! -d $i ] && continue
             [ ${i:0:1} = . ] && continue
 
-            cd ${GITHUB_WORKSPACE}
-            git format-patch --stdout HEAD~1 -- $i > ~/$i.patch
-
             rm -rf ~/$i
             [ -n "${{ secrets.READ_ONLY }}" ] && git clone https://aur.archlinux.org/$i.git ~/$i || git clone ssh://aur@aur.archlinux.org/$i.git ~/$i
 
             cd ~/$i
-            git config user.name $(cat ~/$i.patch | sed -n '/^From:.*>$/{s/^From: \(.*\) <\(.*\)>$/\1/;p}')
-            git config user.email $(cat ~/$i.patch | sed -n '/^From:.*>$/{s/^From: \(.*\) <\(.*\)>$/\2/;p}')
-            git am -p2 ~/$i.patch;
+            rsync -avP --delete --exclude=.git ${GITHUB_WORKSPACE}/$i ~
+            git config user.name ${name}
+            git config user.email ${email}
+            git add .
+            git commit -m "${message}"
+
             [ -n "${{ secrets.READ_ONLY }}" ] && git show || git push origin master
           done

--- a/.github/workflows/sync-to-aur.yml
+++ b/.github/workflows/sync-to-aur.yml
@@ -1,0 +1,42 @@
+name: Sync package to AUR
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save ssh key
+        run: |
+          echo ${{ secrets.AUR_SSH_KEY }} | install -Dm400 /dev/stdin ~/.ssh/id_ed25519
+
+      - name: Install and configure git
+        run: |
+          sudo apt-get install git
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Sync packages to AUR
+        run: |
+          set -x
+          for i in $(git show --pretty="" --name-only | cut -d/ -f1 | sort -u)
+          do
+            [ ! -d $i ] && continue
+            [ ${i:0:1} = . ] && continue
+
+            cd ${GITHUB_WORKSPACE}
+            git format-patch --stdout HEAD~1 -- $i > ~/$i.patch
+
+            rm -rf ~/$i
+            [ -n "${{ secrets.READ_ONLY }}" ] && git clone https://aur.archlinux.org/$i.git ~/$i || git clone ssh://aur@aur.archlinux.org/$i.git ~/$i
+
+            cd ~/$i
+            git config user.name $(cat ~/$i.patch | sed -n '/^From:.*>$/{s/^From: \(.*\) <\(.*\)>$/\1/;p}')
+            git config user.email $(cat ~/$i.patch | sed -n '/^From:.*>$/{s/^From: \(.*\) <\(.*\)>$/\2/;p}')
+            git am -p2 ~/$i.patch;
+            [ -n "${{ secrets.READ_ONLY }}" ] && git show || git push origin master
+          done


### PR DESCRIPTION
<s>Just a start up.
Not tested.</s>

Now it's tested.

### Preview
This is a preview of this action if we bump rocrand's pkgrel by 1.
https://github.com/petronny/rocm-arch/runs/790544983?check_suite_focus=true
It shows what the commit will be but won't push it to AUR.

### Usage
<s>3 secrets are needed.</s>
Only 1 secret is needed now.
`AUR_SSH_KEY`
<s>`GIT_COMMIT_EMAIL`
`GIT_COMMIT_USER`</s>
Then everything should be fine.

There is another one called `READ_ONLY`. It's used for the preview. Don't set it.

### Note
This runs on every push, not every commit.
If you push multiple commits, only the changes in the last commit will be sync.

#251