### PR TITLE
[hipsparse] Update to 3.5.0

### DIFF
--- a/hipsparse/.SRCINFO
+++ b/hipsparse/.SRCINFO
@@ -1,17 +1,17 @@
 pkgbase = hipsparse
 	pkgdesc = rocSPARSE marshalling library.
-	pkgver = 3.3.0
-	pkgrel = 4
+	pkgver = 3.5.0
+	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#hipsparse
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
-	makedepends = hcc
 	makedepends = git
+	makedepends = rocminfo
+	depends = hip-rocclr
 	depends = rocsparse
-	depends = hip-hcc
-	source = hipsparse-3.3.0.tar.gz::https://github.com/ROCmSoftwarePlatform/hipSPARSE/archive/rocm-3.3.0.tar.gz
-	sha256sums = c69336071f56c857e969f0fdfbc351f75cc44ed2e3b854b4688675a9cafe4e22
+	source = hipsparse-3.5.0.tar.gz::https://github.com/ROCmSoftwarePlatform/hipSPARSE/archive/rocm-3.5.0.tar.gz
+	sha256sums = fa16b2a307a5d9716066c2876febcbc1cef855bf0c96d235d2d8f2206a0fb69d
 
 pkgname = hipsparse
 

--- a/hipsparse/PKGBUILD
+++ b/hipsparse/PKGBUILD
@@ -1,40 +1,33 @@
 # Maintainer: Markus Näther <naetherm@informatik.uni-freiburg.de>
 pkgname=hipsparse
-pkgver=3.3.0
-pkgrel=4
+pkgver=3.5.0
+pkgrel=1
 pkgdesc='rocSPARSE marshalling library.'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#hipsparse'
 license=('MIT')
-depends=('rocsparse' 'hip-hcc')
-makedepends=('cmake' 'hcc' 'git')
+depends=('hip-rocclr' 'rocsparse')
+makedepends=('cmake' 'git' 'rocminfo')
 _git='https://github.com/ROCmSoftwarePlatform/hipSPARSE'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
-sha256sums=('c69336071f56c857e969f0fdfbc351f75cc44ed2e3b854b4688675a9cafe4e22')
+sha256sums=('fa16b2a307a5d9716066c2876febcbc1cef855bf0c96d235d2d8f2206a0fb69d')
 
 build() {
-  mkdir -p build
-  cd build
-
-  CXX=/opt/rocm/hcc/bin/hcc \
-  cmake -DCMAKE_INSTALL_PREFIX=opt/rocm/hipsparse \
-        -DCMAKE_CXX_FLAGS='-isystem /opt/rocm/hsa/include' \
-        -Dhcc_DIR=/opt/rocm/hcc/lib/cmake/hcc \
+  CXX=/opt/rocm/hip/bin/hipcc \
+  cmake -B build -Wno-dev \
+        -DCMAKE_INSTALL_PREFIX=opt/rocm \
         -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
+        -DAMDDeviceLibs_DIR=/opt/rocm/lib/cmake/AMDDeviceLibs \
         -Dhip_DIR=/opt/rocm/hip/lib/cmake/hip \
         -Drocsparse_DIR=/opt/rocm/rocsparse/lib/cmake/rocsparse \
         -DBUILD_CLIENTS_SAMPLES=OFF \
         -DBUILD_CLIENTS_TESTS=OFF \
         "$srcdir/hipSPARSE-rocm-$pkgver"
-  make
+  make -C build
 }
 
 package() {
-  cd "$srcdir/build"
-
-  make install
-
-  cp -a "$srcdir/build/opt" "$pkgdir"
+  DESTDIR="$pkgdir" make -C build install
 
   install -Dm644 /dev/stdin "$pkgdir/etc/ld.so.conf.d/hipsparse.conf" << EOF 
 /opt/rocm/hipsparse/lib


### PR DESCRIPTION
Resolves #207 
Currently does not build. Relevant  [upstream issue](https://github.com/ROCmSoftwarePlatform/hipSPARSE/issues/121).