### PR TITLE
[rocm-smi-lib] Update to 3.5.0

### DIFF
--- a/rocm-smi-lib/.SRCINFO
+++ b/rocm-smi-lib/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = rocm-smi-lib
-	pkgdesc = ROCm SMI LIB
-	pkgver = 3.3.0
-	pkgrel = 2
+	pkgdesc = Interface to monitor and control applications on AMD GPUs.
+	pkgver = 3.5.0
+	pkgrel = 1
 	url = https://github.com/RadeonOpenCompute/rocm_smi_lib
 	arch = x86_64
 	license = custom:NCSAOSL
 	makedepends = cmake
 	options = !staticlibs
 	options = strip
-	source = rocm_smi_lib-roc-3.3.0.tar.gz::https://github.com/RadeonOpenCompute/rocm_smi_lib/archive/rocm-3.3.0.tar.gz
-	sha256sums = bb2d98b91963bbd42a449911bcceb7c877f73e866ba92463b06cece87e6cd2f6
+	source = rocm_smi_lib-roc-3.5.0.tar.gz::https://github.com/RadeonOpenCompute/rocm_smi_lib/archive/rocm-3.5.0.tar.gz
+	sha256sums = a5d2ec3570d018b60524f0e589c4917f03d26578443f94bde27a170c7bb21e6e
 
 pkgname = rocm-smi-lib
 

--- a/rocm-smi-lib/PKGBUILD
+++ b/rocm-smi-lib/PKGBUILD
@@ -1,29 +1,27 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rocm-smi-lib
-pkgver=3.3.0
-pkgrel=2
-pkgdesc="ROCm SMI LIB"
+pkgver=3.5.0
+pkgrel=1
+pkgdesc='Interface to monitor and control applications on AMD GPUs.'
 arch=('x86_64')
 url="https://github.com/RadeonOpenCompute/rocm_smi_lib"
 license=('custom:NCSAOSL')
-depends=()
 makedepends=('cmake')
 options=(!staticlibs strip)
 source=("rocm_smi_lib-roc-$pkgver.tar.gz::https://github.com/RadeonOpenCompute/rocm_smi_lib/archive/rocm-$pkgver.tar.gz")
-sha256sums=('bb2d98b91963bbd42a449911bcceb7c877f73e866ba92463b06cece87e6cd2f6')
+sha256sums=('a5d2ec3570d018b60524f0e589c4917f03d26578443f94bde27a170c7bb21e6e')
+_dirname="$(basename $url)-$(basename "${source[0]}" ".tar.gz")"
 
 build() {
-  mkdir -p "$srcdir/build"
-  cd "$srcdir/build"
-
-  cmake -DCMAKE_BUILD_TYPE=Release \
+  cmake -B build -Wno-dev \
+        -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        "$srcdir/rocm_smi_lib-rocm-$pkgver"
-  make
+        -DCMAKE_BUILD_TYPE=Release 
+  make -C build
 }
 
 package() {
-  cd "$srcdir/build"
+  DESTDIR="$pkgdir" make -C build install
 
-  make DESTDIR="$pkgdir" install
+  install -Dm644 "$_dirname/License.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
Successfully builds in a clean chroot. We need `CMAKE_BUILD_TYPE=Release` to enable `_FORTIFY_SOURCE`