### PR TITLE
[miopen-hip] Change compiler to hipcc, add check() function

### DIFF
--- a/miopen-hip/.SRCINFO
+++ b/miopen-hip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = miopen-hip
 	pkgdesc = AMD's Machine Intelligence Library (HIP backend)
 	pkgver = 3.5.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
 	license = custom:NCSAOSL
@@ -16,7 +16,7 @@ pkgbase = miopen-hip
 	depends = hip
 	provides = miopen
 	conflicts = miopen
-	source = miopen-hip-3.5.0::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-3.5.0.tar.gz
+	source = miopen-hip-3.5.0.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-3.5.0.tar.gz
 	sha256sums = aa362e69c4dce7f5751f0ee04c745735ea5454c8101050e9b92cc60fa3c0fb82
 
 pkgname = miopen-hip

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=miopen-hip
 pkgver=3.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="AMD's Machine Intelligence Library (HIP backend)"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
@@ -11,26 +11,29 @@ depends=('rocblas' 'boost' 'llvm-amdgpu' 'rocm-clang-ocl' 'hip')
 makedepends=('cmake' 'rocm-cmake' 'half' 'miopengemm')
 provides=('miopen')
 conflicts=('miopen')
-source=("$pkgname-$pkgver::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
 sha256sums=('aa362e69c4dce7f5751f0ee04c745735ea5454c8101050e9b92cc60fa3c0fb82')
 
 build() {
-  mkdir -p "$srcdir/build"
-  cd "$srcdir/build"
-
-  cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/miopen \
+  CXXFLAGS="$CXXFLAGS -DHALF_ENABLE_F16C_INTRINSICS=0 -isystem /opt/rocm/llvm/lib/clang/11.0.0" \
+  CPPFLAGS="$CPPFLAGS -DHALF_ENABLE_F16C_INTRINSICS=0 -isystem /opt/rocm/llvm/lib/clang/11.0.0" \
+  CXX=/opt/rocm/hip/bin/hipcc \
+  cmake -B build -Wno-dev \
+        -S "MIOpen-rocm-$pkgver" \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm/miopen \
         -DMIOPEN_BACKEND=HIP \
         -DHALF_INCLUDE_DIR=/usr/include/half \
-        -DBoost_NO_BOOST_CMAKE=ON \
-        "$srcdir/MIOpen-rocm-$pkgver"
+        -DBoost_NO_BOOST_CMAKE=ON
 
-  make
+  make -C build
+}
+
+check() {
+    make -C build check
 }
 
 package() {
-  cd "$srcdir/build"
-
-  make DESTDIR="$pkgdir" install
+  DESTDIR="$pkgdir" make -C build install
 
   install -d "$pkgdir/etc/ld.so.conf.d"
   cat << EOF > "$pkgdir/etc/ld.so.conf.d/miopen.conf"

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -28,10 +28,6 @@ build() {
   make -C build
 }
 
-check() {
-    make -C build check
-}
-
 package() {
   DESTDIR="$pkgdir" make -C build install
 


### PR DESCRIPTION
Partially addresses #271 
To compile `miopen-hip` you need to use `hipcc`, i.e. `clang` from `amdgpu-llvm`. I can successfully compile the package but cannot pass all tests. Those that are related to rocBLAS fail at the moment. Could please someone else check this? Maybe @acxz ? I also had to disable the use of intrinsics in the `half` package and manually specify the path to the `clang`-internal header files.