### PR TITLE
[hip-rocclr] Symlink include path to /opt/rocm/include

### DIFF
--- a/hip-rocclr/.SRCINFO
+++ b/hip-rocclr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-rocclr
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.5.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-rocclr
 pkgver=3.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
@@ -33,6 +33,9 @@ package() {
   for _fn in hipcc hipconfig; do
     ln -s "/opt/rocm/hip/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
+  # Some packages search for hip includes in /opt/rocm/include/hip
+  install -d "$pkgdir/opt/rocm/include"
+  ln -s "/opt/rocm/hip/include/hip" "$pkgdir/opt/rocm/include/hip"
 
   install -Dm644 /dev/stdin "$pkgdir/etc/ld.so.conf.d/hip.conf" <<EOF
 /opt/rocm/hip/lib


### PR DESCRIPTION
This is part of a fix for #271.

This PR adds a symlink for the include path `/opt/rocm/hip/include` to `/opt/rocm/include` so that `miopen-hip` can find the HIP header files.