### PR TITLE
[miopen-hip] Successfull build in clean chroot

### DIFF
--- a/miopen-hip/.SRCINFO
+++ b/miopen-hip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = miopen-hip
 	pkgdesc = AMD's Machine Intelligence Library (HIP backend)
 	pkgver = 3.5.0
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
 	license = custom:NCSAOSL
@@ -9,6 +9,8 @@ pkgbase = miopen-hip
 	makedepends = rocm-cmake
 	makedepends = half
 	makedepends = miopengemm
+	makedepends = clang
+	makedepends = rocminfo
 	depends = rocblas
 	depends = boost
 	depends = llvm-amdgpu

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=miopen-hip
 pkgver=3.5.0
-pkgrel=3
+pkgrel=4
 pkgdesc="AMD's Machine Intelligence Library (HIP backend)"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
 license=('custom:NCSAOSL')
 depends=('rocblas' 'boost' 'llvm-amdgpu' 'rocm-clang-ocl' 'hip')
-makedepends=('cmake' 'rocm-cmake' 'half' 'miopengemm')
+makedepends=('cmake' 'rocm-cmake' 'half' 'miopengemm' 'clang' 'rocminfo')
 provides=('miopen')
 conflicts=('miopen')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")


### PR DESCRIPTION
Fixes #271 

This PR needs the updated HIP package from #281 
Additionally add `clang` (for `clang-tidy`) and `rocminfo` as build depends.