### PR TITLE
[rock-dkms-bin] Reversed rock-dkms-bin/PKGBUILD version

### DIFF
--- a/hsa-ext-rocr/.SRCINFO
+++ b/hsa-ext-rocr/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = hsa-ext-rocr
 	pkgdesc = ROCm Platform Runtime: Closed source components
 	pkgver = 3.5.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/ROCR-Runtime
 	arch = x86_64
 	license = EULA
 	depends = hsa-rocr
 	depends = hsakmt-roct
-	source = https://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/hsa-ext-rocr-dev_1.1.30501.0-rocm-rel-3.5-34-def83d8_amd64.deb
-	sha256sums = 0ef5132d086f36ce73161ff21bc4108e33f27cdff838b3f347729497050fa0ac
+	source = https://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/hsa-ext-rocr-dev_1.1.30500.0-rocm-rel-3.5-30-def83d8_amd64.deb
+	sha256sums = e8f5ac2bd13658ab0f471d6088088ec14c791f5f39d163dd4bdbda75021f22a1
 
 pkgname = hsa-ext-rocr
 

--- a/hsa-ext-rocr/PKGBUILD
+++ b/hsa-ext-rocr/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 # Contributor: Bruno Filipe <bmilreu@gmail.com>
 # Contributor: Ranieri Althoff <ranisalt+aur at gmail.com>
+# Contributor: Vinicius Sauer <vsauer at gmail.com>
 
 pkgname=hsa-ext-rocr
 pkgver=3.5.1
-pkgrel=1
-_debfile=hsa-ext-rocr-dev_1.1.30501.0-rocm-rel-3.5-34-def83d8_amd64.deb
+pkgrel=2
+_debfile=hsa-ext-rocr-dev_1.1.30500.0-rocm-rel-3.5-30-def83d8_amd64.deb
 pkgdesc='ROCm Platform Runtime: Closed source components'
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/ROCR-Runtime'
 license=('EULA')
 depends=("hsa-rocr" "hsakmt-roct")
 source=("https://repo.radeon.com/rocm/apt/debian/pool/main/h/hsa-ext-rocr-dev/$_debfile")
-sha256sums=('0ef5132d086f36ce73161ff21bc4108e33f27cdff838b3f347729497050fa0ac')
+sha256sums=('e8f5ac2bd13658ab0f471d6088088ec14c791f5f39d163dd4bdbda75021f22a1')
 
 package() {
   tar -C "$pkgdir" -xf data.tar.gz

--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -14,7 +14,7 @@ pkgbase = rock-dkms-bin
 	backup = etc/modprobe.d/blacklist-radeon.conf
 	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_3.5-30_all.deb
 	source = rock_compatibility.patch::https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch
-	sha256sums = 96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af
+	sha256sums = f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece
 	sha256sums = a8dec1dc7d118844dfe2bbf4beab8b15b69cdae478957dfc5e033997f58d00cb
 
 pkgname = rock-dkms-bin

--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-bin
 	pkgdesc = Linux AMD GPU kernel driver from ROC in DKMS format.
 	pkgver = 3.5
-	pkgrel = 4
+	pkgrel = 5
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL
@@ -12,7 +12,7 @@ pkgbase = rock-dkms-bin
 	options = !strip
 	options = !emptydirs
 	backup = etc/modprobe.d/blacklist-radeon.conf
-	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_3.5-32_all.deb
+	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_3.5-30_all.deb
 	source = rock_compatibility.patch::https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch
 	sha256sums = 96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af
 	sha256sums = a8dec1dc7d118844dfe2bbf4beab8b15b69cdae478957dfc5e033997f58d00cb

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008@yahoo.com>
 pkgname=rock-dkms-bin
 pkgver=3.5
-_pkgver=$pkgver-32
+_pkgver=$pkgver-30
 pkgrel=4
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -1,4 +1,6 @@
 # Maintainer: acxz <akashpatel2008@yahoo.com>
+# Contributor: Vinicius Sauer <vsauer at gmail.com>
+
 pkgname=rock-dkms-bin
 pkgver=3.5
 _pkgver=$pkgver-30
@@ -15,7 +17,7 @@ options=('!strip' '!emptydirs')
 source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb"
         "rock_compatibility.patch"::"https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch")
 
-sha256sums=('96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af'
+sha256sums=('f12a2cc3786bda711413f28be06d5ca0a0d44a441cf824455b0262da595a4ece'
             'a8dec1dc7d118844dfe2bbf4beab8b15b69cdae478957dfc5e033997f58d00cb')
 
 package() {

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=rock-dkms-bin
 pkgver=3.5
 _pkgver=$pkgver-30
-pkgrel=4
+pkgrel=5
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"

--- a/rock-dkms-firmware-bin/.SRCINFO
+++ b/rock-dkms-firmware-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-firmware-bin
 	pkgdesc = Linux AMD GPU firmware from ROC in DKMS format.
 	pkgver = 3.5
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL
@@ -11,7 +11,7 @@ pkgbase = rock-dkms-firmware-bin
 	options = !strip
 	options = !emptydirs
 	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_3.5-30_all.deb
-	sha256sums = 75859a63c09b1fd57da1106b0b20c4d910345d09fa7cd634d6bb73dc5e594313
+	sha256sums = 1777f6b321800f9c0727322c2e5151634fae572889b5c27dfc71549894a4f291
 
 pkgname = rock-dkms-firmware-bin
 

--- a/rock-dkms-firmware-bin/.SRCINFO
+++ b/rock-dkms-firmware-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-firmware-bin
 	pkgdesc = Linux AMD GPU firmware from ROC in DKMS format.
 	pkgver = 3.5
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL
@@ -10,7 +10,7 @@ pkgbase = rock-dkms-firmware-bin
 	conflicts = rock-dkms-firmware
 	options = !strip
 	options = !emptydirs
-	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_3.5-32_all.deb
+	source = http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_3.5-30_all.deb
 	sha256sums = 75859a63c09b1fd57da1106b0b20c4d910345d09fa7cd634d6bb73dc5e594313
 
 pkgname = rock-dkms-firmware-bin

--- a/rock-dkms-firmware-bin/PKGBUILD
+++ b/rock-dkms-firmware-bin/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rock-dkms-firmware-bin
 pkgver=3.5
-_pkgver=$pkgver-32
-pkgrel=2
+_pkgver=$pkgver-30
+pkgrel=3
 pkgdesc="Linux AMD GPU firmware from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"

--- a/rock-dkms-firmware-bin/PKGBUILD
+++ b/rock-dkms-firmware-bin/PKGBUILD
@@ -1,8 +1,10 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
+# Contributor: Vinicius Sauer <vsauer at gmail.com>
+
 pkgname=rock-dkms-firmware-bin
 pkgver=3.5
 _pkgver=$pkgver-30
-pkgrel=3
+pkgrel=4
 pkgdesc="Linux AMD GPU firmware from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"
@@ -13,7 +15,7 @@ conflicts=('rock-dkms-firmware')
 options=('!strip' '!emptydirs')
 source=("http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_${_pkgver}_all.deb")
 
-sha256sums=('75859a63c09b1fd57da1106b0b20c4d910345d09fa7cd634d6bb73dc5e594313')
+sha256sums=('1777f6b321800f9c0727322c2e5151634fae572889b5c27dfc71549894a4f291')
 
 package() {
   cd "$srcdir"


### PR DESCRIPTION
==> Making package: rock-dkms-firmware-bin 3.5-2 (Mon 29 Jun 2020 05:42:50 PM PDT)
==> Retrieving sources...
  -> Downloading rock-dkms-firmware_3.5-32_all.deb...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
==> ERROR: Failure while downloading http://repo.radeon.com/rocm/apt/debian/pool/main/r/rock-dkms/rock-dkms-firmware_3.5-32_all.deb
    Aborting...
Error downloading sources: rock-dkms-firmware-bin