### PR TITLE
[rocrand] rocrand headers in rocm/include folder

### DIFF
--- a/rocrand/.SRCINFO
+++ b/rocrand/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocrand
 	pkgdesc = Pseudo-random and quasi-random number generator on ROCm
 	pkgver = 3.5.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#rocrand
 	arch = x86_64
 	license = MIT

--- a/rocrand/PKGBUILD
+++ b/rocrand/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jakub Okoński <jakub@okonski.org>
 pkgname=rocrand
 pkgver=3.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Pseudo-random and quasi-random number generator on ROCm'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#rocrand'
@@ -34,5 +34,6 @@ package() {
 /opt/rocm/rocrand/lib
 EOF
   install -Dm644 "$srcdir/rocRAND-rocm-$pkgver/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-  ln -s "/opt/rocm/hiprand/include/hiprand.h" "$pkgdir/opt/rocm/include/hiprand/hiprand.h"
+  mkdir "$pkgdir/opt/rocm/include/hiprand"
+  ln -s "/opt/rocm/hiprand/include/" "$pkgdir/opt/rocm/include/hiprand/"
 }

--- a/rocrand/PKGBUILD
+++ b/rocrand/PKGBUILD
@@ -34,4 +34,5 @@ package() {
 /opt/rocm/rocrand/lib
 EOF
   install -Dm644 "$srcdir/rocRAND-rocm-$pkgver/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  ln -s "/opt/rocm/hiprand/include/hiprand.h" "$pkgdir/opt/rocm/include/hiprand/hiprand.h"
 }


### PR DESCRIPTION
This PR is associated with [another PR](https://github.com/rocm-arch/tensorflow-rocm/pull/4).

The `rocrand` headers are not symlinked to the standard rocm headers folder `rocm/include` folder.