### PR TITLE
[rock-dkms-bin] Update patch for #267

### DIFF
--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-bin
 	pkgdesc = Linux AMD GPU kernel driver from ROC in DKMS format.
 	pkgver = 3.5.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL
@@ -13,7 +13,9 @@ pkgbase = rock-dkms-bin
 	options = !emptydirs
 	backup = etc/modprobe.d/blacklist-radeon.conf
 	source = rock-dkms-bin-3.5.1.tar.gz::http://repo.radeon.com/rocm/apt/3.5.1/pool/main/r/rock-dkms/rock-dkms_3.5-32_all.deb
+	source = rock_compatibility.patch::https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch
 	sha256sums = 96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af
+	sha256sums = 82b9ef05c67f538bbdf07f066e059d623db2bdb7b67a1b695dab3659601092dc
 
 pkgname = rock-dkms-bin
 

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -22,10 +22,9 @@ package() {
 
   tar xf data.tar.xz -C "$pkgdir"
 
-  grep "dkms/Makefile b" rock_compatibility.patch -A 26 >> Makefile.patch
-
-  cd $pkgdir/usr/src/amdgpu-${_pkgver}/amd
-  patch --forward -p4 dkms/Makefile --input=${srcdir}/Makefile.patch
+  cd $pkgdir/usr/src/amdgpu-${_pkgver}
+  patch --forward -p4 -t --input=${srcdir}/rock_compatibility.patch > patching.log \
+     || echo "patch is meant to fail as not all files from the kernel is in the binary"
 
   install -Dm644 "$pkgdir/usr/share/doc/rock-dkms/copyright" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=rock-dkms-bin
 pkgver=3.5.1
 _pkgver=3.5-32
-pkgrel=1
+pkgrel=2
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"
@@ -12,13 +12,20 @@ provides=('rock-dkms')
 conflicts=('rock-dkms')
 backup=('etc/modprobe.d/blacklist-radeon.conf')
 options=('!strip' '!emptydirs')
-source=("${pkgname}-${pkgver}.tar.gz"::"http://repo.radeon.com/rocm/apt/${pkgver}/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb")
-sha256sums=('96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af')
+source=("${pkgname}-${pkgver}.tar.gz"::"http://repo.radeon.com/rocm/apt/${pkgver}/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb"
+        "rock_compatibility.patch"::"https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch")
+sha256sums=('96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af'
+            '82b9ef05c67f538bbdf07f066e059d623db2bdb7b67a1b695dab3659601092dc')
 
 package() {
   cd "$srcdir"
 
   tar xf data.tar.xz -C "$pkgdir"
+
+  grep "dkms/Makefile b" rock_compatibility.patch -A 26 >> Makefile.patch
+
+  cd $pkgdir/usr/src/amdgpu-${_pkgver}/amd
+  patch --forward -p4 dkms/Makefile --input=${srcdir}/Makefile.patch
 
   install -Dm644 "$pkgdir/usr/share/doc/rock-dkms/copyright" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
Regarding issue #267 ( and #269 )
I've not had time to test this in depth, but it seems to work on 5.6 and 5.7.0
However, not on 5.7.8 ( a header, `dt-bindings/leds/common.h` is missing during dkms build )
