### PR TITLE
[rocclr] Fix OpenCL includes

### DIFF
--- a/rocclr/.SRCINFO
+++ b/rocclr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocclr
 	pkgdesc = Radeon Open Compute Common Language Runtime
 	pkgver = 3.5.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/ROCm-Developer-Tools/ROCclr
 	arch = x86_64
 	license = unknown
@@ -13,8 +13,10 @@ pkgbase = rocclr
 	depends = rocm-cmake
 	source = rocclr-3.5.0.tar.gz::https://github.com/ROCm-Developer-Tools/ROCclr/archive/roc-3.5.0.tar.gz
 	source = rocclr-opencl-3.5.0.tar.gz::https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/roc-3.5.0.tar.gz
+	source = opencl_includes.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/ROCclr/pull/16.patch
 	sha256sums = 87c1ee9f02b8aa487b628c543f058198767c474cec3d21700596a73c028959e1
 	sha256sums = 511b617d5192f2d4893603c1a02402b2ac9556e9806ff09dd2a91d398abf39a0
+	sha256sums = 3edeb8aeaf335297ec0f61a15b99c259d607d8f534173fbc3d17832ad03cd63f
 
 pkgname = rocclr
 

--- a/rocclr/PKGBUILD
+++ b/rocclr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer Torsten Keßler <t dot kessler at posteo dot de>
 pkgname=rocclr
 pkgver=3.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Radeon Open Compute Common Language Runtime'
 arch=('x86_64')
 url='https://github.com/ROCm-Developer-Tools/ROCclr'
@@ -10,22 +10,29 @@ depends=('mesa' 'comgr' 'hsa-rocr' 'hsakmt-roct' 'rocm-cmake')
 makedepends=('cmake')
 _opencl='https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime'
 source=("$pkgname-$pkgver.tar.gz::$url/archive/roc-$pkgver.tar.gz"
-        "$pkgname-opencl-$pkgver.tar.gz::$_opencl/archive/roc-$pkgver.tar.gz")
+        "$pkgname-opencl-$pkgver.tar.gz::$_opencl/archive/roc-$pkgver.tar.gz"
+	'opencl_includes.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/ROCclr/pull/16.patch')
 sha256sums=('87c1ee9f02b8aa487b628c543f058198767c474cec3d21700596a73c028959e1'
-            '511b617d5192f2d4893603c1a02402b2ac9556e9806ff09dd2a91d398abf39a0')
+            '511b617d5192f2d4893603c1a02402b2ac9556e9806ff09dd2a91d398abf39a0'
+	    '3edeb8aeaf335297ec0f61a15b99c259d607d8f534173fbc3d17832ad03cd63f')
+_dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+
+prepare() {
+	cd "$_dirname"
+	patch -Np1 -i "$srcdir/opencl_includes.patch"
+}
 
 build() {
-    mkdir -p build
-    cd build
-    cmake "$srcdir/ROCclr-roc-$pkgver" \
-        -DCMAKE_INSTALL_PREFIX='/opt/rocm/rocclr' \
+    cmake -Wno-dev -B build \
+	-S "$srcdir/$_dirname" \
+	-DCMAKE_INSTALL_PREFIX='/opt/rocm/rocclr' \
         -DOPENCL_DIR="$srcdir/ROCm-OpenCL-Runtime-roc-$pkgver"
 
-    make
+    make -C build
 }
 
 package() {
-    make -C build DESTDIR="$pkgdir/" install
+    DESTDIR="$pkgdir" make -C build install
 
     sed -i "s@$srcdir/build/libamdrocclr_static.a@/opt/rocm/rocclr/lib/libamdrocclr_static.a@" \
         "$srcdir/build/amdrocclr_staticTargets.cmake"


### PR DESCRIPTION
The default behavior of `cmake` seems to have changed with version 3.18 such that ROCclr's `CMakeLists.txt` does not work anymore. The patch is submitted as an upstream PR [here](https://github.com/ROCm-Developer-Tools/ROCclr/pull/16). The relevant issue is https://github.com/ROCm-Developer-Tools/ROCclr/issues/15