### PR TITLE
[rock-dkms-bin] Patch file updated, build fails

### DIFF
--- a/rock-dkms-bin/.SRCINFO
+++ b/rock-dkms-bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rock-dkms-bin
 	pkgdesc = Linux AMD GPU kernel driver from ROC in DKMS format.
 	pkgver = 3.5.1
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver
 	arch = any
 	license = GPL
@@ -15,7 +15,7 @@ pkgbase = rock-dkms-bin
 	source = rock-dkms-bin-3.5.1.tar.gz::http://repo.radeon.com/rocm/apt/3.5.1/pool/main/r/rock-dkms/rock-dkms_3.5-32_all.deb
 	source = rock_compatibility.patch::https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch
 	sha256sums = 96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af
-	sha256sums = 82b9ef05c67f538bbdf07f066e059d623db2bdb7b67a1b695dab3659601092dc
+	sha256sums = SKIP
 
 pkgname = rock-dkms-bin
 

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -15,7 +15,7 @@ options=('!strip' '!emptydirs')
 source=("${pkgname}-${pkgver}.tar.gz"::"http://repo.radeon.com/rocm/apt/${pkgver}/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb"
         "rock_compatibility.patch"::"https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch")
 sha256sums=('96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af'
-            '82b9ef05c67f538bbdf07f066e059d623db2bdb7b67a1b695dab3659601092dc')
+            '4d82038c47a0d9425511ae9118fde911e62351fbcf72d05ec7612c25de727324')
 
 package() {
   cd "$srcdir"

--- a/rock-dkms-bin/PKGBUILD
+++ b/rock-dkms-bin/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=rock-dkms-bin
 pkgver=3.5.1
 _pkgver=3.5-32
-pkgrel=2
+pkgrel=3
 pkgdesc="Linux AMD GPU kernel driver from ROC in DKMS format."
 arch=('any')
 url="https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver"
@@ -15,7 +15,7 @@ options=('!strip' '!emptydirs')
 source=("${pkgname}-${pkgver}.tar.gz"::"http://repo.radeon.com/rocm/apt/${pkgver}/pool/main/r/rock-dkms/rock-dkms_${_pkgver}_all.deb"
         "rock_compatibility.patch"::"https://patch-diff.githubusercontent.com/raw/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95.patch")
 sha256sums=('96bb0730df239e9c7ea6b0086060dff04a31e620a08c51e7b1f9235858dbe2af'
-            '4d82038c47a0d9425511ae9118fde911e62351fbcf72d05ec7612c25de727324')
+            'SKIP')
 
 package() {
   cd "$srcdir"


### PR DESCRIPTION
The build for `rock-dkms-bin` fails for the checksum on `rock_compatibility.patch`. Looking at the PKGBUILD, it pulls directly from the [repo pull request](https://github.com/RadeonOpenCompute/ROCK-Kernel-Driver/pull/95). This request was updated 16 hours ago, and the patch checksum no longer matches. 

```
==> Making package: rock-dkms-bin 3.5.1-2 (Fri 14 Aug 2020 09:45:52 PM MDT)
==> Retrieving sources...
  -> Downloading rock-dkms-bin-3.5.1.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5365k  100 5365k    0     0  5975k      0 --:--:-- --:--:-- --:--:-- 5968k
  -> Downloading rock_compatibility.patch...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 73174    0 73174    0     0  42741      0 --:--:--  0:00:01 --:--:-- 42741
==> Validating source files with sha256sums...
    rock-dkms-bin-3.5.1.tar.gz ... Passed
    rock_compatibility.patch ... FAILED
==> ERROR: One or more files did not pass the validity check!
error downloading sources: rock-dkms-bin
```
New checksum:

`4d82038c47a0d9425511ae9118fde911e62351fbcf72d05ec7612c25de727324  rock_compatibility.patch`

**I have done absolutely no testing of this new patch file.**
