### PR TITLE
[llvm-amdgpu-git] Remove thread logic, add compiler-rt

### DIFF
--- a/llvm-amdgpu-git/.SRCINFO
+++ b/llvm-amdgpu-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = llvm-amdgpu-git
 	pkgdesc = Radeon Open Compute - LLVM toolchain (llvm, clang, lld)
 	pkgver = latest
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/llvm-project
 	arch = x86_64
 	license = custom:Apache 2.0 with LLVM Exception

--- a/llvm-amdgpu-git/PKGBUILD
+++ b/llvm-amdgpu-git/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=llvm-amdgpu-git
 pkgdesc='Radeon Open Compute - LLVM toolchain (llvm, clang, lld)'
 pkgver=latest
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/llvm-project'
 license=('custom:Apache 2.0 with LLVM Exception')
@@ -20,23 +20,13 @@ pkgver() {
 }
 
 build() {
-    # building LLVM/Clang requires ~1.5G per unit
-    THREADS=$(( ($(getconf _PHYS_PAGES) * $(getconf PAGESIZE)) / 1610612736 ))
-    if [ "$THREADS" -lt 1 ]; then
-        THREADS=1
-    fi
-    NPROC=$(nproc)
-    if [ "$THREADS" -gt $(nproc) ]; then
-        THREADS="$NPROC"
-    fi
-
     cmake -DCMAKE_INSTALL_PREFIX='/opt/rocm/llvm' \
           -DCMAKE_BUILD_TYPE=Release \
           -DLLVM_HOST_TRIPLE=$CHOST \
           -DLLVM_BUILD_UTILS=ON \
           -DLLVM_ENABLE_BINDINGS=OFF \
           -DLLVM_ENABLE_OCAMLDOC=OFF \
-          -DLLVM_ENABLE_PROJECTS='llvm;clang;lld' \
+          -DLLVM_ENABLE_PROJECTS='llvm;clang;compiler-rt;lld' \
           -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
           -DOCAMLFIND=NO \
           "$pkgname/llvm"


### PR DESCRIPTION
compiler-rt is needed for ROCm 3.7.0, see #368
