### PR TITLE
[rocsparse] Update to 3.7.0

### DIFF
--- a/rocsparse/.SRCINFO
+++ b/rocsparse/.SRCINFO
@@ -1,16 +1,19 @@
 pkgbase = rocsparse
 	pkgdesc = BLAS for sparse computation on top of ROCm
-	pkgver = 3.5.0
+	pkgver = 3.7.0
 	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#rocsparse
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
 	makedepends = git
+	makedepends = gcc-fortran
 	depends = hip-rocclr
 	depends = rocprim
-	source = rocsparse-3.5.0.tar.gz::https://github.com/ROCmSoftwarePlatform/rocSPARSE/archive/rocm-3.5.0.tar.gz
-	sha256sums = 9ca6bae7da78abbb47143c3d77ff4a8cd7d63979875fc7ebc46b400769fd9cb5
+	source = rocsparse-3.7.0.tar.gz::https://github.com/ROCmSoftwarePlatform/rocSPARSE/archive/rocm-3.7.0.tar.gz
+	source = remove-boz-literals.patch::https://patch-diff.githubusercontent.com/raw/ROCmSoftwarePlatform/rocSPARSE/pull/210.patch
+	sha256sums = db561ae5e8ee117f7c539a9ef6ee49c13b82ba9f702b22c76e741cca245386a9
+	sha256sums = bb34dd66788f1456cf2a711ec537441933b89ffde080de6f941bdfe71585c445
 
 pkgname = rocsparse
 

--- a/rocsparse/PKGBUILD
+++ b/rocsparse/PKGBUILD
@@ -1,36 +1,39 @@
 # Maintainer: Markus Näther <naetherm@informatik.uni-freiburg.de>
 pkgname=rocsparse
-pkgver=3.5.0
+pkgver=3.7.0
 pkgrel=1
 pkgdesc='BLAS for sparse computation on top of ROCm'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#rocsparse'
 license=('MIT')
 depends=('hip-rocclr' 'rocprim')
-makedepends=('cmake' 'git')
+makedepends=('cmake' 'git' 'gcc-fortran')
 _git='https://github.com/ROCmSoftwarePlatform/rocSPARSE'
-source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
-sha256sums=('9ca6bae7da78abbb47143c3d77ff4a8cd7d63979875fc7ebc46b400769fd9cb5')
+source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
+        'remove-boz-literals.patch::https://patch-diff.githubusercontent.com/raw/ROCmSoftwarePlatform/rocSPARSE/pull/210.patch')
+sha256sums=('db561ae5e8ee117f7c539a9ef6ee49c13b82ba9f702b22c76e741cca245386a9'
+            'bb34dd66788f1456cf2a711ec537441933b89ffde080de6f941bdfe71585c445')
+_dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
+
+prepare() {
+    cd "$_dirname"
+    patch -Np1 -i "$srcdir/remove-boz-literals.patch"
+}
 
 build() {
-  mkdir -p build
-  cd build
-
   CXX=/opt/rocm/hip/bin/hipcc \
-  cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+  cmake -Wno-dev -S "$_dirname" \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -Drocprim_DIR=/opt/rocm/rocprim/rocprim/lib/cmake/rocprim \
-        -DBUILD_CLIENTS_SAMPLES=OFF \
-        "$srcdir/rocSPARSE-rocm-$pkgver"
+        -DBUILD_CLIENTS_SAMPLES=OFF
   make
 }
 
 package() {
-  cd "$srcdir/build"
-
-  make DESTDIR="$pkgdir" install
+  DESTDIR="$pkgdir" make install
 
   install -Dm644 /dev/stdin "$pkgdir/etc/ld.so.conf.d/rocsparse.conf" <<EOF
 /opt/rocm/rocsparse/lib
 EOF
-  install -Dm644 "$srcdir/rocSPARSE-rocm-$pkgver/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 "$_dirname/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
Resolves #361

With 3.7.0, `rocsparse` has introduced a fortran interface. However, the code does not compile with newer `gfortran` versions. Relevent upstream PR: https://github.com/ROCmSoftwarePlatform/rocSPARSE/pull/210