### PR TITLE
[hip-rocclr] Build in clean chroot

### DIFF
--- a/hip-rocclr/.SRCINFO
+++ b/hip-rocclr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-rocclr
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.7.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -18,7 +18,7 @@ _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 build() {
   CXXFLAGS="$CXXFLAGS -isystem /opt/rocm/rocclr/include/compiler/lib/include" \
   cmake -B build -Wno-dev \
-  	-S "$_dirname" \
+        -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip \
         -DCMAKE_PREFIX_PATH='/opt/rocm/lib/cmake/hsa-runtime64;/opt/rocm/lib/cmake/amd_comgr' \
         -DHIP_COMPILER=clang \

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-rocclr
 pkgver=3.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
@@ -13,16 +13,17 @@ conflicts=('hip')
 _git='https://github.com/ROCm-Developer-Tools/HIP'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
 sha256sums=('757b392c3beb29beea27640832fbad86681dbd585284c19a4c2053891673babd')
+_dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 
 build() {
+  CXXFLAGS="$CXXFLAGS -isystem /opt/rocm/rocclr/include/compiler/lib/include" \
   cmake -B build -Wno-dev \
+  	-S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip \
         -DCMAKE_PREFIX_PATH='/opt/rocm/lib/cmake/hsa-runtime64;/opt/rocm/lib/cmake/amd_comgr' \
         -DHIP_COMPILER=clang \
-        -DHIP_PLATFORM=rocclr \
-        -DROCCLR_DIR=/opt/rocm/rocclr \
-        "$srcdir/HIP-rocm-$pkgver"
-  make -C build
+        -DHIP_PLATFORM=rocclr
+  make -C build VERBOSE=1
 }
 
 package() {


### PR DESCRIPTION
Resolves #387

Some header files weren't found because one of ROCclr's cmake files referenced a file in the build dir instead of `/opt/rocm`.
