### PR TITLE
Remove yay from readme, remove outdated warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,38 @@
 # ROCm for Arch Linux
 This repository hosts a collection of [Arch Linux](https://www.archlinux.org/) [PKGBUILDs](https://wiki.archlinux.org/index.php/PKGBUILD) for the [AMD ROCm Platform](https://rocmdocs.amd.com/en/latest/).
-These scripts implement a great portion of the stack, ranging from low level interfaces, over compilers and high-level application librariers.
+These scripts implement a great portion of the stack, ranging from low level interfaces, over compilers to high-level application librariers.
 
 ## Installation
 The Arch Linux packages for ROCm are available on the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
-Since many packages will be installed, it is recommended to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers)
-like [`yay`](https://aur.archlinux.org/packages/yay/).
-
-It is also recommended to use the [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu) binary repository as it will
+Since many packages will be installed, we recommend to use the [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu) binary repository as it will
 greatly speed up your installation time.
 For directions see [Add arch4edu to your Archlinux](https://github.com/arch4edu/arch4edu/wiki/Add-arch4edu-to-your-Archlinux).
 
-To install ROCm, use the following command:
+To install ROCm, use
+```bash
+# pacman -Syu rocm-dev rocm-utils rocm-libs
 ```
-yay -S rocm-dkms
-```
-> **Warning**: Building the compiler `llvm-amdgpu` needs a lot of RAM (over 40 GiB on 12 threads) and disk space (more than 50 GiB). We recommend to use a [swap file](https://wiki.archlinux.org/index.php/swap#Swap_file).
 
 You can also install specific ROCm packages like so:
-```
-yay -S rocminfo
+```bash
+# pacman -S rocminfo
 ```
 
 For additional installation configuration, such as adding a user to the `video`
 group, we refer to AMD's [installation guide](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html).
 
 To uninstall, use the following command:
-```
-yay -R rocm-dkms
+```bash
+# pacman -R rocm-dev rocm-utils rocm-libs
 ```
 
 For more helpful tips see the ArchWiki entry on ROCm, [here](https://wiki.archlinux.org/index.php/GPGPU#ROCm).
 
 ## Contributing
-Any contribution is always welcome. You can use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report problems with the AUR packages.
+Your contribution is always welcome. You can use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report problems with the AUR packages.
 Optimally, you open a pull request that solves your problem.
 For most packages, you have to update `pkgver` and `sha256sums`. Before you commit your changes please generate `.SRCINFO` from the updated `PKGBUILD`:
-```
+```bash
 makepkg --printsrcinfo > .SRCINFO
 ```
 and add it to your commit.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more helpful tips see the ArchWiki entry on ROCm, [here](https://wiki.archli
 ## Contributing
 Your contribution is always welcome. Use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report problems with the AUR packages.
 Optimally, you open a pull request that solves your problem.
-For most packages, you have to update `pkgver` and `sha256sums`. Before you commit your changes you will need generate `.SRCINFO` from the updated `PKGBUILD`:
+For most packages, you have to update `pkgver` and `sha256sums`. Before you commit your changes you will need to generate `.SRCINFO` from the updated `PKGBUILD`:
 ```bash
 makepkg --printsrcinfo > .SRCINFO
 ```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # ROCm for Arch Linux
 This repository hosts a collection of [Arch Linux](https://www.archlinux.org/) [PKGBUILDs](https://wiki.archlinux.org/index.php/PKGBUILD) for the [AMD ROCm Platform](https://rocmdocs.amd.com/en/latest/).
-These scripts implement a great portion of the stack, ranging from low level interfaces, over compilers to high-level application librariers.
+These scripts implement a great portion of the stack, ranging from low-level interfaces, over compilers to high-level application librariers.
 
 ## Installation
 The Arch Linux packages for ROCm are available on the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
-Since many packages will be installed, we recommend to use the [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu) binary repository as it will
-greatly speed up your installation time.
+Since many packages will be installed, we recommend to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) like [`yay`](https://aur.archlinux.org/packages/yay/).
+Binary versions are hosted by [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu). Using them will greatly speed up your installation time.
 For directions see [Add arch4edu to your Archlinux](https://github.com/arch4edu/arch4edu/wiki/Add-arch4edu-to-your-Archlinux).
 
 To install ROCm, use
 ```bash
-# pacman -Syu rocm-dev rocm-utils rocm-libs
+yay -S rocm-dev rocm-utils rocm-libs
 ```
+which includes the low-level components and compilers (`rocm-dev`), utilities like `rocminfo` (`rocm-utils`) and GPU-accelerated math libraries (`rocm-libs').
 
 You can also install specific ROCm packages like so:
 ```bash
-# pacman -S rocminfo
+yay -S rocminfo
 ```
 
 For additional installation configuration, such as adding a user to the `video`
@@ -23,15 +24,15 @@ group, we refer to AMD's [installation guide](https://rocmdocs.amd.com/en/latest
 
 To uninstall, use the following command:
 ```bash
-# pacman -R rocm-dev rocm-utils rocm-libs
+yay -R rocm-dev rocm-utils rocm-libs
 ```
 
 For more helpful tips see the ArchWiki entry on ROCm, [here](https://wiki.archlinux.org/index.php/GPGPU#ROCm).
 
 ## Contributing
-Your contribution is always welcome. You can use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report problems with the AUR packages.
+Your contribution is always welcome. Use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report problems with the AUR packages.
 Optimally, you open a pull request that solves your problem.
-For most packages, you have to update `pkgver` and `sha256sums`. Before you commit your changes please generate `.SRCINFO` from the updated `PKGBUILD`:
+For most packages, you have to update `pkgver` and `sha256sums`. Before you commit your changes you will need generate `.SRCINFO` from the updated `PKGBUILD`:
 ```bash
 makepkg --printsrcinfo > .SRCINFO
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ These scripts implement a great portion of the stack, ranging from low-level int
 
 ## Installation
 The Arch Linux packages for ROCm are available on the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
-Since many packages will be installed, we recommend to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) like [`yay`](https://aur.archlinux.org/packages/yay/).
-Binary versions are hosted by [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu). Using them will greatly speed up your installation time.
+Since many packages will be installed, it is recommended to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers)
+like [`yay`](https://aur.archlinux.org/packages/yay/).
+
+It is also recommended to use the [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu) binary repository as it will
+greatly speed up your installation time.
 For directions see [Add arch4edu to your Archlinux](https://github.com/arch4edu/arch4edu/wiki/Add-arch4edu-to-your-Archlinux).
 
 To install ROCm, use


### PR DESCRIPTION
~~Many issues seem to originate from `yay`'s caching. That's why I removed it from our README~~.
We agreed on explicitly mentioning `yay`.
I would like to hear @acxz's opinion on this before we merge it.