### PR TITLE
[rocrand] Add support for gfx803

### DIFF
--- a/rocrand/.SRCINFO
+++ b/rocrand/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocrand
 	pkgdesc = Pseudo-random and quasi-random number generator on ROCm
 	pkgver = 3.7.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#rocrand
 	arch = x86_64
 	license = MIT

--- a/rocrand/PKGBUILD
+++ b/rocrand/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jakub Okoński <jakub@okonski.org>
 pkgname=rocrand
 pkgver=3.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Pseudo-random and quasi-random number generator on ROCm'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/ROCm_Libraries/ROCm_Libraries.html#rocrand'
@@ -17,6 +17,7 @@ build() {
   CXX=/opt/rocm/hip/bin/hipcc \
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+        -DAMDGPU_TARGETS='gfx803;gfx900;gfx906;gfx908' \
         -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
         -DBUILD_TEST=OFF
   make


### PR DESCRIPTION
For unknown reason, `cmake` overwrites the list `AMDGPU_TARGETS`, thereby removing `gfx803`. Manually specifying `AMDGPU_TARGETS` fixes the problem.
I've created this PR because of https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/issues/1106#issuecomment-689536115