### PR TITLE
[miopen-hip] Make sure clang-offload-bundler is used

### DIFF
--- a/miopen-hip/.SRCINFO
+++ b/miopen-hip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = miopen-hip
 	pkgdesc = AMD's Machine Intelligence Library (HIP backend)
 	pkgver = 3.7.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=miopen-hip
 pkgver=3.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc="AMD's Machine Intelligence Library (HIP backend)"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
@@ -22,6 +22,7 @@ build() {
         -S "MIOpen-rocm-$pkgver" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DMIOPEN_BACKEND=HIP \
+        -DMIOPEN_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
         -DHALF_INCLUDE_DIR=/usr/include/half \
         -DBoost_NO_BOOST_CMAKE=ON
 


### PR DESCRIPTION
What is this about?
===================

First of all, it fixes https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/issues/1110

It would seem miopen's  CMake logic currently only looks for `clang-offload-bundler`, if `MIOPEN_HIP_COMPILER`
is clang++. If undefined, it falls back to `hipcc`, which results in `extractkernel` being used.

Upstream _miopen_ is built with `clang-offload-bundler` support, according to
`/opt/rocm-3.7.0/miopen/include/miopen/config.h` in the official docker container.

With this change in place, the config headers are essentially the same:

```patch
--- build/include/miopen/config.h	2020-09-12 00:01:00.140410402 +0200
+++ upstream/include/miopen/config.h	2020-09-11 23:34:40.735846511 +0200
@@ -49,7 +49,7 @@
 // clang-format off
 #define HIP_PACKAGE_VERSION_MAJOR 3
 #define HIP_PACKAGE_VERSION_MINOR 7
-#define HIP_PACKAGE_VERSION_PATCH 20364
+#define HIP_PACKAGE_VERSION_PATCH 20315
 // clang-format on

 // clang-format off
@@ -68,8 +68,8 @@
 #define MIOPEN_USE_RNE_BFLOAT16 1

 #define MIOPEN_AMDGCN_ASSEMBLER "/opt/rocm/llvm/bin/clang"
-#define HIP_OC_COMPILER "/opt/rocm/bin/clang-ocl"
-#define MIOPEN_HIP_COMPILER "/opt/rocm/llvm/bin/clang++"
+#define HIP_OC_COMPILER "/opt/rocm-3.7.0/bin/clang-ocl"
+#define MIOPEN_HIP_COMPILER "/opt/rocm-3.7.0/llvm/bin/clang++"
 /* #undef EXTRACTKERNEL_BIN */
 #define MIOPEN_OFFLOADBUNDLER_BIN "/opt/rocm/llvm/bin/clang-offload-bundler"
 #define MIOPEN_CACHE_DIR "~/.cache/miopen/"
```

Additional info
===============

CMake output _before_ the change:
---------------------------------

```
[...]
-- Build with HIP 3.7.20364
-- Hip compiler flags:  -x hip --hip-device-lib-path=/opt/rocm/lib     -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -D__HIP_ROCclr__=1 -isystem /opt/rocm/hip/../include -isystem /opt/rocm/llvm/lib/clang/11.0.0/include/..  -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -D__HIP_PLATFORM_HCC__=1  -D__HIP_ROCclr__=1 -isystem /opt/rocm/hip/include -isystem /opt/rocm/include -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 --hip-link     -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64
-- hip compiler: /opt/rocm/bin/clang-ocl
-- Build with rocblas
-- HIP backend selected.
-- clang-offload-bundler not found
-- extractkernel found: /opt/rocm/hip/bin/extractkernel
-- AMDGCN assembler: /opt/rocm/llvm/bin/clang
-- Build without miopengemm
[...]
```

CMake output _after_ the change:
--------------------------------
```
[...]
-- Build with HIP 3.7.20364
-- Hip compiler flags:  -x hip --hip-device-lib-path=/opt/rocm/lib     -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -D__HIP_ROCclr__=1 -isystem /opt/rocm/hip/../include -isystem /opt/rocm/llvm/lib/clang/11.0.0/include/..  -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -D__HIP_PLATFORM_HCC__=1  -D__HIP_ROCclr__=1 -isystem /opt/rocm/hip/include -isystem /opt/rocm/include -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 --hip-link     -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64
-- hip compiler: /opt/rocm/bin/clang-ocl
-- Build with rocblas
-- HIP backend selected.
-- clang-offload-bundler found: /opt/rocm/llvm/bin/clang-offload-bundler
-- AMDGCN assembler: /opt/rocm/llvm/bin/clang
-- Build without miopengemm
[...]
```

