### PR TITLE
[hip-rocclr] Update to 3.8.0

### DIFF
--- a/hip-rocclr/.SRCINFO
+++ b/hip-rocclr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-rocclr
 	pkgdesc = Heterogeneous Interface for Portability ROCm
-	pkgver = 3.7.0
-	pkgrel = 4
+	pkgver = 3.8.0
+	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT
@@ -9,12 +9,13 @@ pkgbase = hip-rocclr
 	makedepends = python
 	makedepends = git
 	depends = rocclr
+	depends = rocminfo
 	depends = libelf
 	provides = hip
 	conflicts = hip
-	source = hip-rocclr-3.7.0.tar.gz::https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-3.7.0.tar.gz
+	source = hip-rocclr-3.8.0.tar.gz::https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-3.8.0.tar.gz
 	source = amdgpu-targets.patch
-	sha256sums = 757b392c3beb29beea27640832fbad86681dbd585284c19a4c2053891673babd
+	sha256sums = 6450baffe9606b358a4473d5f3e57477ca67cff5843a84ee644bcf685e75d839
 	sha256sums = c6358b4dfac658c0a27a3425ace455d951cd26be827dd7751c28cb83dc84b67d
 
 pkgname = hip-rocclr

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -1,19 +1,19 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-rocclr
-pkgver=3.7.0
-pkgrel=4
+pkgver=3.8.0
+pkgrel=1
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
 license=('MIT')
-depends=('rocclr' 'libelf')
+depends=('rocclr' 'rocminfo' 'libelf')
 makedepends=('cmake' 'python' 'git')
 provides=('hip')
 conflicts=('hip')
 _git='https://github.com/ROCm-Developer-Tools/HIP'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
         'amdgpu-targets.patch')
-sha256sums=('757b392c3beb29beea27640832fbad86681dbd585284c19a4c2053891673babd'
+sha256sums=('6450baffe9606b358a4473d5f3e57477ca67cff5843a84ee644bcf685e75d839'
             'c6358b4dfac658c0a27a3425ace455d951cd26be827dd7751c28cb83dc84b67d')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 


### PR DESCRIPTION
Resolves #426

Update package to new release and add rocminfo as a dependency to fix warnings of unitialized perl variables in the hipcc script.
