### PR TITLE
Hip rocclr 3.9.0

### DIFF
--- a/hip-rocclr/.SRCINFO
+++ b/hip-rocclr/.SRCINFO
@@ -1,22 +1,23 @@
 pkgbase = hip-rocclr
 	pkgdesc = Heterogeneous Interface for Portability ROCm
-	pkgver = 3.8.0
+	pkgver = 3.9.0
 	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
 	makedepends = python
-	makedepends = git
 	depends = rocclr
 	depends = rocminfo
 	depends = libelf
 	provides = hip
 	conflicts = hip
-	source = hip-rocclr-3.8.0.tar.gz::https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-3.8.0.tar.gz
+	source = hip-rocclr-3.9.0.tar.gz::https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-3.9.0.tar.gz
 	source = amdgpu-targets.patch
-	sha256sums = 6450baffe9606b358a4473d5f3e57477ca67cff5843a84ee644bcf685e75d839
+	source = disable-git-versioning.patch
+	sha256sums = 25ad58691456de7fd9e985629d0ed775ba36a2a0e0b21c086bd96ba2fb0f7ed1
 	sha256sums = c6358b4dfac658c0a27a3425ace455d951cd26be827dd7751c28cb83dc84b67d
+	sha256sums = 1945ff2456e1a0a9c27a79655dcf49af877aac42570c0ab70c7fd8e651335bde
 
 pkgname = hip-rocclr
 

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -13,10 +13,10 @@ conflicts=('hip')
 _git='https://github.com/ROCm-Developer-Tools/HIP'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
         'amdgpu-targets.patch'
-	'disable-git-versioning.patch')
+        'disable-git-versioning.patch')
 sha256sums=('25ad58691456de7fd9e985629d0ed775ba36a2a0e0b21c086bd96ba2fb0f7ed1'
             'c6358b4dfac658c0a27a3425ace455d951cd26be827dd7751c28cb83dc84b67d'
-	    '1945ff2456e1a0a9c27a79655dcf49af877aac42570c0ab70c7fd8e651335bde')
+	      '1945ff2456e1a0a9c27a79655dcf49af877aac42570c0ab70c7fd8e651335bde')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 
 prepare() {

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -1,35 +1,39 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-rocclr
-pkgver=3.8.0
+pkgver=3.9.0
 pkgrel=1
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
 license=('MIT')
 depends=('rocclr' 'rocminfo' 'libelf')
-makedepends=('cmake' 'python' 'git')
+makedepends=('cmake' 'python')
 provides=('hip')
 conflicts=('hip')
 _git='https://github.com/ROCm-Developer-Tools/HIP'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
-        'amdgpu-targets.patch')
-sha256sums=('6450baffe9606b358a4473d5f3e57477ca67cff5843a84ee644bcf685e75d839'
-            'c6358b4dfac658c0a27a3425ace455d951cd26be827dd7751c28cb83dc84b67d')
+        'amdgpu-targets.patch'
+	'disable-git-versioning.patch')
+sha256sums=('25ad58691456de7fd9e985629d0ed775ba36a2a0e0b21c086bd96ba2fb0f7ed1'
+            'c6358b4dfac658c0a27a3425ace455d951cd26be827dd7751c28cb83dc84b67d'
+	    '1945ff2456e1a0a9c27a79655dcf49af877aac42570c0ab70c7fd8e651335bde')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 
 prepare() {
     cd "$_dirname"
     patch -Np1 -i "$srcdir/amdgpu-targets.patch"
+    patch -Np1 -i "$srcdir/disable-git-versioning.patch"
 }
 
 build() {
-  CXXFLAGS="$CXXFLAGS -isystem /opt/rocm/rocclr/include/compiler/lib/include" \
+  CXXFLAGS="$CXXFLAGS -isystem /opt/rocm/rocclr/include/compiler/lib/include -isystem /opt/rocm/rocclr/include/elf" \
   cmake -B build -Wno-dev \
         -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip \
         -DCMAKE_PREFIX_PATH='/opt/rocm/lib/cmake/hsa-runtime64;/opt/rocm/lib/cmake/amd_comgr' \
         -DHIP_COMPILER=clang \
-        -DHIP_PLATFORM=rocclr
+        -DHIP_PLATFORM=rocclr \
+	-D__HIP_ENABLE_PCH=OFF
   make -C build
 }
 

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -33,7 +33,7 @@ build() {
         -DCMAKE_PREFIX_PATH='/opt/rocm/lib/cmake/hsa-runtime64;/opt/rocm/lib/cmake/amd_comgr' \
         -DHIP_COMPILER=clang \
         -DHIP_PLATFORM=rocclr \
-	-D__HIP_ENABLE_PCH=OFF
+        -D__HIP_ENABLE_PCH=OFF
   make -C build
 }
 

--- a/hip-rocclr/disable-git-versioning.patch
+++ b/hip-rocclr/disable-git-versioning.patch
@@ -1,0 +1,69 @@
+*** HIP-rocm-3.9.0/CMakeLists.txt.bak	2020-11-01 11:24:23.406720145 +0100
+--- HIP-rocm-3.9.0/CMakeLists.txt	2020-11-01 11:24:45.703264460 +0100
+***************
+*** 44,99 ****
+  list(GET VERSION_LIST 0 HIP_VERSION_MAJOR)
+  list(GET VERSION_LIST 1 HIP_VERSION_MINOR)
+  
+! find_package(Git)
+! 
+! # FIXME: Two different version strings used.
+! if(GIT_FOUND)
+!   # get date information based on UTC
+!   # use the last two digits of year + week number + day in the week as HIP_VERSION_GITDATE
+!   # use the commit date, instead of build date
+!   # add xargs to remove strange trailing newline character
+!   execute_process(COMMAND ${GIT_EXECUTABLE} show -s --format=@%ct
+!     COMMAND xargs
+!     COMMAND date -f - --utc +%y%U%w
+!     RESULT_VARIABLE git_result
+!     OUTPUT_VARIABLE git_output
+!     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+!     OUTPUT_STRIP_TRAILING_WHITESPACE)
+!   if(git_result EQUAL 0)
+!     set(HIP_VERSION_GITDATE ${git_output})
+!   endif()
+! 
+!   # get commit short hash
+!   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+!     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+!     RESULT_VARIABLE git_result
+!     OUTPUT_VARIABLE git_output
+!     OUTPUT_STRIP_TRAILING_WHITESPACE)
+!   if(git_result EQUAL 0)
+!     set(HIP_VERSION_GITHASH ${git_output})
+!   endif()
+! 
+!   # get commit count
+!   execute_process(COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
+!     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+!     RESULT_VARIABLE git_result
+!     OUTPUT_VARIABLE git_output
+!     OUTPUT_STRIP_TRAILING_WHITESPACE)
+!   if(git_result EQUAL 0)
+!     set(HIP_VERSION_GITCOUNT ${git_output})
+!   endif()
+! 
+!   set(HIP_VERSION_PATCH ${HIP_VERSION_GITDATE}-${HIP_VERSION_GITHASH})
+! 
+!   if(DEFINED ENV{ROCM_BUILD_ID})
+!     set(HIP_PACKAGING_VERSION_PATCH ${HIP_VERSION_GITDATE}.${HIP_VERSION_GITCOUNT}-$ENV{ROCM_BUILD_ID}-${HIP_VERSION_GITHASH})
+!   else()
+!     set(HIP_PACKAGING_VERSION_PATCH ${HIP_VERSION_GITDATE}.${HIP_VERSION_GITCOUNT}-${HIP_VERSION_GITHASH})
+!   endif()
+! else()
+!   # FIXME: Some parts depend on this being set.
+!   set(HIP_PACKAGING_VERSION_PATCH "0")
+! endif()
+  
+  add_to_config(_versionInfo HIP_VERSION_MAJOR)
+  add_to_config(_versionInfo HIP_VERSION_MINOR)
+--- 44,51 ----
+  list(GET VERSION_LIST 0 HIP_VERSION_MAJOR)
+  list(GET VERSION_LIST 1 HIP_VERSION_MINOR)
+  
+! # FIXME: Some parts depend on this being set.
+! set(HIP_PACKAGING_VERSION_PATCH "0")
+  
+  add_to_config(_versionInfo HIP_VERSION_MAJOR)
+  add_to_config(_versionInfo HIP_VERSION_MINOR)


### PR DESCRIPTION
For the new version to compile, I had to disable precompiled headers. Otherwise, `cmake` fails after a while with `file not found` errors. Furthermore, I removed the option for `cmake` to generate a verbose version string if `git` is available. This addresses #448.