### PR TITLE
Patched pacman-specific solution for action command_string

### DIFF
--- a/rocm-validation-suite/.SRCINFO
+++ b/rocm-validation-suite/.SRCINFO
@@ -14,7 +14,9 @@ pkgbase = rocm-validation-suite
 	options = !staticlibs
 	options = strip
 	source = rocm-validation-suite-3.9.0.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-3.9.0.tar.gz
+	source = action.patch
 	sha256sums = 17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555
+	sha256sums = 16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9
 
 pkgname = rocm-validation-suite
 

--- a/rocm-validation-suite/.SRCINFO
+++ b/rocm-validation-suite/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-validation-suite
 	pkgdesc = Tool for detecting and troubleshooting common problems affecting AMD GPUs
 	pkgver = 3.9.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCm-Developer-Tools/ROCmValidationSuite
 	arch = x86_64
 	license = MIT
@@ -16,7 +16,7 @@ pkgbase = rocm-validation-suite
 	source = rocm-validation-suite-3.9.0.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-3.9.0.tar.gz
 	source = action.patch
 	sha256sums = 17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555
-	sha256sums = 16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9
+	sha256sums = 8edac06b0658c77f91ce77bbfbe539c4f001b27ab205aabcad91cbecf19bd4d0
 
 pkgname = rocm-validation-suite
 

--- a/rocm-validation-suite/PKGBUILD
+++ b/rocm-validation-suite/PKGBUILD
@@ -13,7 +13,7 @@ options=(!staticlibs strip)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-$pkgver.tar.gz"
         "action.patch")
 sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555'
-            '16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9')
+            '8edac06b0658c77f91ce77bbfbe539c4f001b27ab205aabcad91cbecf19bd4d0')
 
 prepare() {
   cd "$srcdir/ROCmValidationSuite-rocm-$pkgver"
@@ -41,5 +41,4 @@ package() {
     ln -s "/opt/rocm/rvs/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 }
-sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555'
-            '8edac06b0658c77f91ce77bbfbe539c4f001b27ab205aabcad91cbecf19bd4d0')
+

--- a/rocm-validation-suite/PKGBUILD
+++ b/rocm-validation-suite/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rocm-validation-suite
 pkgver=3.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Tool for detecting and troubleshooting common problems affecting AMD
 GPUs"
 arch=('x86_64')
@@ -10,13 +10,17 @@ license=('MIT')
 depends=('pciutils' 'doxygen' 'rocblas' 'rocm-smi-lib64' 'git')
 makedepends=('cmake')
 options=(!staticlibs strip)
-source=("$pkgname-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-$pkgver.tar.gz" "action.patch")
-sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555' '16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-$pkgver.tar.gz"
+        "action.patch")
+sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555'
+            '16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9')
+
+prepare() {
+ cd $srcdir
+ patch ROCmValidationSuite-rocm-$pkgver/rcqt.so/src/action.cpp action.patch 
+}
 
 build() {
-  cd $srcdir
-  patch ROCmValidationSuite-rocm-3.9.0/rcqt.so/src/action.cpp action.patch 
-
   mkdir -p "$srcdir/build"
   cd "$srcdir/build"
 

--- a/rocm-validation-suite/PKGBUILD
+++ b/rocm-validation-suite/PKGBUILD
@@ -10,10 +10,13 @@ license=('MIT')
 depends=('pciutils' 'doxygen' 'rocblas' 'rocm-smi-lib64' 'git')
 makedepends=('cmake')
 options=(!staticlibs strip)
-source=("$pkgname-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-$pkgver.tar.gz")
-sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/ROCm-Developer-Tools/ROCmValidationSuite/archive/rocm-$pkgver.tar.gz" "action.patch")
+sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555' '16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9')
 
 build() {
+  cd $srcdir
+  patch ROCmValidationSuite-rocm-3.9.0/rcqt.so/src/action.cpp action.patch 
+
   mkdir -p "$srcdir/build"
   cd "$srcdir/build"
 

--- a/rocm-validation-suite/PKGBUILD
+++ b/rocm-validation-suite/PKGBUILD
@@ -16,8 +16,8 @@ sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555'
             '16059a24ae9c01a7e77e1323a2437b9222998d3ac19d7c3367bcf821da60ecd9')
 
 prepare() {
- cd $srcdir
- patch ROCmValidationSuite-rocm-$pkgver/rcqt.so/src/action.cpp action.patch 
+  cd "$srcdir/ROCmValidationSuite-rocm-$pkgver"
+  patch --forward --strip=1 --input="${srcdir}/action.patch"
 }
 
 build() {
@@ -41,3 +41,5 @@ package() {
     ln -s "/opt/rocm/rvs/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 }
+sha256sums=('17662028a4485b97e3ccaad5e94d20aaa2c3e9e3f741c7ebbf0f8b4cdebcc555'
+            '8edac06b0658c77f91ce77bbfbe539c4f001b27ab205aabcad91cbecf19bd4d0')

--- a/rocm-validation-suite/PKGBUILD
+++ b/rocm-validation-suite/PKGBUILD
@@ -41,4 +41,3 @@ package() {
     ln -s "/opt/rocm/rvs/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 }
-

--- a/rocm-validation-suite/action.patch
+++ b/rocm-validation-suite/action.patch
@@ -1,0 +1,17 @@
+--- src/ROCmValidationSuite-rocm-3.9.0/rcqt.so/src/action.cpp	2020-09-24 10:09:40.000000000 +0200
++++ action.cpp	2020-11-02 15:32:36.464149284 +0100
+@@ -196,13 +196,7 @@
+   // Checking if version field exists
+   string version_name;
+   version_exists = has_property(VERSION, &version_name);
+-  #if RVS_OS_TYPE_NUM == 1
+-  string command_string = "dpkg --get-selections > ";
+-  #endif
+-  #if RVS_OS_TYPE_NUM == 2
+-  string command_string = "rpm -qa --qf \"%{NAME}\n\" > ";
+-  #endif
+-  command_string += PKG_CMD_FILE;
++  string command_string = "pacman -Q > ";
+ 
+   // We execute the dpkg-querry
+   if (system(command_string.c_str()) == -1) {

--- a/rocm-validation-suite/action.patch
+++ b/rocm-validation-suite/action.patch
@@ -1,5 +1,6 @@
---- src/ROCmValidationSuite-rocm-3.9.0/rcqt.so/src/action.cpp	2020-09-24 10:09:40.000000000 +0200
-+++ action.cpp	2020-11-02 15:32:36.464149284 +0100
+diff --unified --recursive --text package.orig/rcqt.so/src/action.cpp package.new/rcqt.so/src/action.cpp
+--- package.orig/rcqt.so/src/action.cpp	2020-11-02 20:52:54.346675345 +0100
++++ package.new/rcqt.so/src/action.cpp	2020-11-02 20:53:23.430008727 +0100
 @@ -196,13 +196,7 @@
    // Checking if version field exists
    string version_name;


### PR DESCRIPTION
Patch described here: https://github.com/rocm-arch/rocm-arch/issues/64#issuecomment-720572802

It compiles but doesn't really work and more importantly compile every test.

It seems like the string variable in question is just for printing the installed packages into a system, so I replaced it with a arch-specific command.