### PR TITLE
Fix bitcode directory path

### DIFF
--- a/rocm-clang-ocl/.SRCINFO
+++ b/rocm-clang-ocl/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-clang-ocl
 	pkgdesc = OpenCL compilation with clang compiler.
 	pkgver = 3.9.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/clang-ocl
 	arch = x86_64
 	license = unknown

--- a/rocm-clang-ocl/PKGBUILD
+++ b/rocm-clang-ocl/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Lucas Magalhães <whoisroot@national.shitposting.agency>
 pkgname=rocm-clang-ocl
 pkgver=3.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenCL compilation with clang compiler."
 arch=('x86_64')
 url="https://github.com/RadeonOpenCompute/clang-ocl"

--- a/rocm-clang-ocl/PKGBUILD
+++ b/rocm-clang-ocl/PKGBUILD
@@ -17,7 +17,7 @@ build() {
   cmake -Wno-dev -B build \
         -S "$_dirname" \
         -DCLANG_BIN=/opt/rocm/llvm/bin \
-        -DBITCODE_DIR=/opt/rocm/lib \
+        -DBITCODE_DIR=/opt/rocm/amdgcn/bitcode \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm
 
   make -C build


### PR DESCRIPTION
I installed all of rocm today, and this was one of the modules that did not build.
I fixed the bitcode directory path to the correct location.

I am on Manjaro, so I don't know if there are differences on other Arch systems.