### PR TITLE
[rocm-gdb] Update PKGBUILD to 3.9.0 to match rocm-dbgapi dependency

### DIFF
--- a/rocm-gdb/.SRCINFO
+++ b/rocm-gdb/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-gdb
 	pkgdesc = ROCm source-level debugger for Linux, based on GDB
-	pkgver = 3.8.0
+	pkgver = 3.9.0
 	pkgrel = 1
 	url = https://github.com/ROCm-Developer-Tools/ROCgdb
 	arch = x86_64
@@ -16,8 +16,8 @@ pkgbase = rocm-gdb
 	depends = mpfr
 	depends = source-highlight
 	depends = babeltrace
-	source = rocm-gdb-3.8.0.tar.gz::https://github.com/ROCm-Developer-Tools/ROCgdb/archive/rocm-3.8.0.tar.gz
-	sha256sums = a7c11dc30c952587c616bf7769bad603c3bf80522afc8b73ccda5b78d27bed41
+	source = rocm-gdb-3.9.0.tar.gz::https://github.com/ROCm-Developer-Tools/ROCgdb/archive/rocm-3.9.0.tar.gz
+	sha256sums = 0765c96439c0efa145418d210d865b9faed463466d7522274959cc4476a37097
 
 pkgname = rocm-gdb
 

--- a/rocm-gdb/PKGBUILD
+++ b/rocm-gdb/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer Torsten Keßler <t dot kessler at posteo dot de>
 pkgname=rocm-gdb
-pkgver=3.8.0
+pkgver=3.9.0
 pkgrel=1
 pkgdesc='ROCm source-level debugger for Linux, based on GDB'
 arch=('x86_64')
@@ -9,7 +9,7 @@ license=('GPL')
 depends=('rocm-dbgapi' 'python' 'guile2.0' 'ncurses' 'expat' 'xz' 'zlib' 'mpfr' 'source-highlight' 'babeltrace')
 makedepends=('texinfo')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
-sha256sums=('a7c11dc30c952587c616bf7769bad603c3bf80522afc8b73ccda5b78d27bed41')
+sha256sums=('0765c96439c0efa145418d210d865b9faed463466d7522274959cc4476a37097')
 _dirname="$(basename "$url")-$(basename "${source[0]}" ".tar.gz")"
 
 prepare() {


### PR DESCRIPTION
Updating rocm-gdb to version 3.9.0 to fix issues with incompatible headers between both dependencies, closes #469.