### PR TITLE
[hip-rocclr] Link hipVersion file to /opt/rocm/bin

### DIFF
--- a/hip-rocclr/.SRCINFO
+++ b/hip-rocclr/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-rocclr
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 3.9.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT

--- a/hip-rocclr/PKGBUILD
+++ b/hip-rocclr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-rocclr
 pkgver=3.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
@@ -39,6 +39,10 @@ build() {
 
 package() {
   DESTDIR="$pkgdir" make -C build install
+
+  # clang from llvm-amdgpu may look for hipVersion in a different directory
+  install -d "$pkgdir/opt/rocm/bin"
+  ln -s '/opt/rocm/hip/bin/.hipVersion' "$pkgdir/opt/rocm/bin/.hipVersion"
 
   # add links (hipconfig is for rocblas with tensile)
   install -d "$pkgdir/usr/bin"


### PR DESCRIPTION
Resolves #468

When calling `hipcc` (only a `perl` around `clang` from `llvm-amdgpu`), `clang` looks for the HIP runtime. As an indicator whether it is installed, it uses the (hidden) file `.hipVersion` which is installed by `cmake` to `/opt/rocm/hip/bin` (This is also where it is located in the debian package). The search path however is relative to `clang` (as far as I understood by inspecting the source code), so the `.hipVersion` file needs to be put in `/opt/rocm/bin`.