### PR TITLE
[llvm-amdgpu] Update to 3.10.0

### DIFF
--- a/llvm-amdgpu/.SRCINFO
+++ b/llvm-amdgpu/.SRCINFO
@@ -1,15 +1,16 @@
 pkgbase = llvm-amdgpu
 	pkgdesc = Radeon Open Compute - LLVM toolchain (llvm, clang, lld)
-	pkgver = 3.9.0
-	pkgrel = 2
+	pkgver = 3.10.0
+	pkgrel = 1
 	url = https://github.com/RadeonOpenCompute/llvm-project
 	arch = x86_64
 	license = custom:Apache 2.0 with LLVM Exception
 	makedepends = cmake
 	makedepends = python
+	makedepends = ninja
 	depends = z3
-	source = llvm-amdgpu-3.9.0.tar.gz::https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-3.9.0.tar.gz
-	sha256sums = 1ff14b56d10c2c44d36c3c412b190d3d8cd1bb12cfc7cd58af004c16fd9987d1
+	source = llvm-amdgpu-3.10.0.tar.gz::https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-3.10.0.tar.gz
+	sha256sums = 8262aff88c1ff6c4deb4da5a4f8cda1bf90668950e2b911f93f73edaee53b370
 
 pkgname = llvm-amdgpu
 

--- a/llvm-amdgpu/PKGBUILD
+++ b/llvm-amdgpu/PKGBUILD
@@ -2,19 +2,19 @@
 
 pkgname=llvm-amdgpu
 pkgdesc='Radeon Open Compute - LLVM toolchain (llvm, clang, lld)'
-pkgver=3.9.0
-pkgrel=2
+pkgver=3.10.0
+pkgrel=1
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/llvm-project'
 license=('custom:Apache 2.0 with LLVM Exception')
 depends=(z3)
-makedepends=(cmake python)
+makedepends=(cmake python ninja)
 source=("${pkgname}-${pkgver}.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
-sha256sums=('1ff14b56d10c2c44d36c3c412b190d3d8cd1bb12cfc7cd58af004c16fd9987d1')
+sha256sums=('8262aff88c1ff6c4deb4da5a4f8cda1bf90668950e2b911f93f73edaee53b370')
 _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
 
 build() {
-    cmake -Wno-dev -S "$_dirname/llvm" \
+    cmake -GNinja -Wno-dev -S "$_dirname/llvm" \
           -DCMAKE_INSTALL_PREFIX='/opt/rocm/llvm' \
           -DCMAKE_BUILD_TYPE=Release \
           -DLLVM_HOST_TRIPLE=$CHOST \
@@ -24,9 +24,9 @@ build() {
           -DLLVM_ENABLE_PROJECTS='llvm;clang;compiler-rt;lld' \
           -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
           -DOCAMLFIND=NO
-    make
+    ninja
 }
 
 package() {
-    DESTDIR="$pkgdir" make install
+    DESTDIR="$pkgdir" ninja install
 }


### PR DESCRIPTION
I also replaced `make` with `ninja` in compliance with upstream and the arch `llvm` package. This reduces the compilation time from 50 min. to 33 min on my machine.