### PR TITLE
[miopen-hip] Update to 4.0.0

### DIFF
--- a/miopen-hip/.SRCINFO
+++ b/miopen-hip/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = miopen-hip
 	pkgdesc = AMD's Machine Intelligence Library (HIP backend)
-	pkgver = 3.10.0
+	pkgver = 4.0.0
 	pkgrel = 1
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
@@ -18,8 +18,7 @@ pkgbase = miopen-hip
 	depends = hip
 	provides = miopen
 	conflicts = miopen
-	source = miopen-hip-3.10.0.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-3.10.0.tar.gz
-	sha256sums = 926e43c5583cf70d6b247f9fe45971b8b1cc9668f9c8490c142c7e8b6e268f1a
+	source = miopen-hip-4.0.0.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-4.0.0.tar.gz
+	sha256sums = 84c6c17be9c1a9cd0d3a2af283433f64b07a4b9941349f498e40fed82fb205a6
 
 pkgname = miopen-hip
-

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel at yahoo dot com>
 
 pkgname=miopen-hip
-pkgver=3.10.0
+pkgver=4.0.0
 pkgrel=1
 pkgdesc="AMD's Machine Intelligence Library (HIP backend)"
 arch=('x86_64')
@@ -12,7 +12,7 @@ makedepends=('cmake' 'rocm-cmake' 'half' 'miopengemm' 'clang' 'rocminfo')
 provides=('miopen')
 conflicts=('miopen')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
-sha256sums=('926e43c5583cf70d6b247f9fe45971b8b1cc9668f9c8490c142c7e8b6e268f1a')
+sha256sums=('84c6c17be9c1a9cd0d3a2af283433f64b07a4b9941349f498e40fed82fb205a6')
 
 build() {
   CXXFLAGS="$CXXFLAGS -DHALF_ENABLE_F16C_INTRINSICS=0 -isystem /opt/rocm/llvm/lib/clang/11.0.0" \


### PR DESCRIPTION
Package does not compile at the moment, see https://github.com/ROCmSoftwarePlatform/MIOpen/issues/658