### PR TITLE
[miopen-hip] Boost noinline fix

### DIFF
--- a/miopen-hip/.SRCINFO
+++ b/miopen-hip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = miopen-hip
 	pkgdesc = AMD's Machine Intelligence Library (HIP backend)
 	pkgver = 4.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
 	license = custom:NCSAOSL
@@ -22,3 +22,4 @@ pkgbase = miopen-hip
 	sha256sums = 84c6c17be9c1a9cd0d3a2af283433f64b07a4b9941349f498e40fed82fb205a6
 
 pkgname = miopen-hip
+

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -1,8 +1,9 @@
 # Maintainer: acxz <akashpatel at yahoo dot com>
+# Contributor: JP-Ellis <josh@jpellis.me>
 
 pkgname=miopen-hip
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="AMD's Machine Intelligence Library (HIP backend)"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
@@ -15,16 +16,13 @@ source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
 sha256sums=('84c6c17be9c1a9cd0d3a2af283433f64b07a4b9941349f498e40fed82fb205a6')
 
 build() {
-  CXXFLAGS="$CXXFLAGS -DHALF_ENABLE_F16C_INTRINSICS=0 -isystem /opt/rocm/llvm/lib/clang/11.0.0" \
-  CPPFLAGS="$CPPFLAGS -DHALF_ENABLE_F16C_INTRINSICS=0 -isystem /opt/rocm/llvm/lib/clang/11.0.0" \
-  CXX=/opt/rocm/hip/bin/hipcc \
+  CXX=/opt/rocm/llvm/bin/clang++ \
+  CXXFLAGS="$CXXFLAGS -DBOOST_CONTAINER_DISABLE_NOINLINE=ON" \
   cmake -B build -Wno-dev \
         -S "MIOpen-rocm-$pkgver" \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DMIOPEN_BACKEND=HIP \
-        -DMIOPEN_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
-        -DHALF_INCLUDE_DIR=/usr/include/half \
-        -DBoost_NO_BOOST_CMAKE=ON
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+        -DHALF_INCLUDE_DIR=/usr/include/half
 
   make -C build
 }


### PR DESCRIPTION
- Change compiled from `hcc` to rocm's `clang++` as per the MIOpen build
  instructions,
- Add `BOOST_CONTAINER_DISABLE_NOINLINE` to fix an issue with `noinline` not
  being defined,
- Remove `HALF_ENABLE_F16C_INTRINSICS` as it should be automatically set (as per
  http://half.sourceforge.net/half_8hpp.html#a9f8c77eb299462e092d2df4d2d2b7abf),
- Remove `MIOPEN_HIP_COMPILER` as it is automatically determined by CMake based
  on `CMAKE_INSTALL_PREFIX`,
- Remove `Boost_NO_BOOST_CMAKE` flag as it does not seem to do anything

Note that although this fixes #511, the issue described in #509 remains.