### PR TITLE
Add version files for rocm-dev, rocm-utils and rocm-libs

### DIFF
--- a/rocm-dev/.SRCINFO
+++ b/rocm-dev/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-dev
 	pkgdesc = ROCm Dev - Metapackage for the ROCm Development Stack
 	pkgver = 4.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
 	depends = comgr

--- a/rocm-dev/PKGBUILD
+++ b/rocm-dev/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rocm-dev
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROCm Dev - Metapackage for the ROCm Development Stack"
 arch=('x86_64')
 url="https://rocm-documentation.readthedocs.io/en/latest/"
@@ -14,3 +14,8 @@ depends=('comgr' 'hip-rocclr' 'hsa-amd-aqlprofile' 'hsakmt-roct' 'llvm-amdgpu'
 makedepends=()
 source=()
 sha256sums=()
+
+package() {
+	mkdir -p "${pkgdir}/opt/rocm/.info"
+	echo "${pkgver}-${pkgrel}" > "${pkgdir}/opt/rocm/.info/version-dev"
+}

--- a/rocm-libs/.SRCINFO
+++ b/rocm-libs/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-libs
 	pkgdesc = ROCm Libs - Libraries utilizing HPC and Ultrascale GPU Computing of ROCm
 	pkgver = 4.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
 	depends = hipblas

--- a/rocm-libs/PKGBUILD
+++ b/rocm-libs/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 pkgname=rocm-libs
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROCm Libs - Libraries utilizing HPC and Ultrascale GPU Computing of
 ROCm"
 arch=('x86_64')
@@ -12,3 +12,8 @@ depends=('hipblas' 'hipcub' 'hipsparse' 'miopen-hip' 'rocalution' 'rocblas'
 makedepends=()
 source=()
 sha256sums=()
+
+package() {
+	mkdir -p "${pkgdir}/opt/rocm/.info"
+	echo "${pkgver}-${pkgrel}" > "${pkgdir}/opt/rocm/.info/version-libs"
+}

--- a/rocm-utils/.SRCINFO
+++ b/rocm-utils/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-utils
 	pkgdesc = ROCm Platform Runtime: Utils
 	pkgver = 4.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
 	depends = rocminfo

--- a/rocm-utils/PKGBUILD
+++ b/rocm-utils/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Lucas Magalhães <whoisroot@national.shitposting.agency>
 pkgname=rocm-utils
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ROCm Platform Runtime: Utils"
 arch=('x86_64')
 url="https://rocm-documentation.readthedocs.io/en/latest/"
@@ -11,3 +11,8 @@ depends=('rocminfo' 'rocm-clang-ocl')
 makedepends=()
 source=()
 sha256sums=()
+
+package() {
+	mkdir -p "${pkgdir}/opt/rocm/.info"
+	echo "${pkgver}-${pkgrel}" > "${pkgdir}/opt/rocm/.info/version-utils"
+}


### PR DESCRIPTION
tensorflow-rocm 2.4.0 looks for these files to know which rocm version it builds against.

These files are contained in the upstream rocm-dev, rocm-utils and rocm-libs RPMs for RHEL/CentOS 8:
https://repo.radeon.com/rocm/centos8/4.0/