### PR TITLE
Fix tensorflow include

### DIFF
--- a/llvm-amdgpu/PKGBUILD
+++ b/llvm-amdgpu/PKGBUILD
@@ -14,17 +14,24 @@ source=("${pkgname}-${pkgver}.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
 sha256sums=('8003ede5a1462f46f0bb1b8b16c14ac6e884d322561235f7111ef7c3e74c6b07')
 _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
 
+prepare() {
+    cmake -GNinja \
+        -Wno-dev \
+        -S "$_dirname/llvm" \
+        -DCMAKE_INSTALL_PREFIX='/opt/rocm/llvm' \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_HOST_TRIPLE=$CHOST \
+        -DLLVM_BUILD_UTILS=ON \
+        -DLLVM_ENABLE_BINDINGS=OFF \
+        -DLLVM_ENABLE_OCAMLDOC=OFF \
+        -DLLVM_ENABLE_PROJECTS='llvm;clang;compiler-rt;lld' \
+        -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
+        -DOCAMLFIND=NO \
+        -DCMAKE_CXX_FLAGS='-I/usr/include/tensorflow' \
+        -DTENSORFLOW_AOT_PATH='/usr/lib/python3.9/site-packages/tensorflow'
+}
+
 build() {
-    cmake -GNinja -Wno-dev -S "$_dirname/llvm" \
-          -DCMAKE_INSTALL_PREFIX='/opt/rocm/llvm' \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DLLVM_HOST_TRIPLE=$CHOST \
-          -DLLVM_BUILD_UTILS=ON \
-          -DLLVM_ENABLE_BINDINGS=OFF \
-          -DLLVM_ENABLE_OCAMLDOC=OFF \
-          -DLLVM_ENABLE_PROJECTS='llvm;clang;compiler-rt;lld' \
-          -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
-          -DOCAMLFIND=NO
     ninja
 }
 

--- a/llvm-amdgpu/PKGBUILD
+++ b/llvm-amdgpu/PKGBUILD
@@ -13,8 +13,9 @@ makedepends=(cmake python ninja)
 source=("${pkgname}-${pkgver}.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
 sha256sums=('8003ede5a1462f46f0bb1b8b16c14ac6e884d322561235f7111ef7c3e74c6b07')
 _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+_pythonver=$(python --version | grep -o "[[:digit:]].[[:digit:]]")
 
-prepare() {
+build() {
     cmake -GNinja \
         -Wno-dev \
         -S "$_dirname/llvm" \
@@ -28,10 +29,7 @@ prepare() {
         -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
         -DOCAMLFIND=NO \
         -DCMAKE_CXX_FLAGS='-I/usr/include/tensorflow' \
-        -DTENSORFLOW_AOT_PATH='/usr/lib/python3.9/site-packages/tensorflow'
-}
-
-build() {
+        -DTENSORFLOW_AOT_PATH='/usr/lib/python${_pythonver}/site-packages/tensorflow'
     ninja
 }
 


### PR DESCRIPTION
When tensorflow is installed, the CMake script tries to locates `/usr/lib/libtensorflow.so`, and if found enables some additional components of LLVM.  Unfortunately, it assumes that the Tensorflow headers are located in `/usr/include`, but they are in fact installed in `/usr/include/tensorflow`.

This PR also moves the call to CMake into prepare instead of build.

Let me know if you wish to also update the release.

This fixes #572.