### PR TITLE
[llvm-amdgpu] Fix quotes

### DIFF
--- a/llvm-amdgpu/PKGBUILD
+++ b/llvm-amdgpu/PKGBUILD
@@ -29,7 +29,7 @@ build() {
         -DLLVM_TARGETS_TO_BUILD='AMDGPU;X86' \
         -DOCAMLFIND=NO \
         -DCMAKE_CXX_FLAGS='-I/usr/include/tensorflow' \
-        -DTENSORFLOW_AOT_PATH='/usr/lib/python${_pythonver}/site-packages/tensorflow'
+        -DTENSORFLOW_AOT_PATH="/usr/lib/python${_pythonver}/site-packages/tensorflow"
     ninja
 }
 


### PR DESCRIPTION
In previous commit, I quickly fixed a hard-coded Python 3.9 version to automatically detect it; except I forgot to changes the string to use double quotes.

I should've seen that, but it was such a trivial fix replace `3.9` with `${_pythonver}` that I didn't think twice.

As before, as this is such a minor fixup in the PKGBUILD and does not change the produced package, I did not bother bumping `pkgrel`.