### PR TITLE
[rccl] add gmock dep and release 4.1.0

### DIFF
--- a/rccl/.SRCINFO
+++ b/rccl/.SRCINFO
@@ -1,15 +1,17 @@
 pkgbase = rccl
 	pkgdesc = ROCm Communication Collectives Library
-	pkgver = 4.0.0
+	pkgver = 4.1.0
 	pkgrel = 1
 	url = https://github.com/ROCmSoftwarePlatform/rccl
 	arch = x86_64
 	license = custom
 	makedepends = cmake
 	makedepends = python
+	makedepends = gmock
 	depends = hip
 	depends = gtest
-	source = rccl-4.0.0.tar.gz::https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-4.0.0.tar.gz
-	sha256sums = 0632a15b3d6b5981c05377cf4aeb51546f4c4901fd7c37fb0c98071851ad531a
+	source = rccl-4.1.0.tar.gz::https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-4.1.0.tar.gz
+	sha256sums = 88ec9b43c31cb054fe6aa28bcc0f4b510213635268f951939d6980eee5bb3680
 
 pkgname = rccl
+

--- a/rccl/PKGBUILD
+++ b/rccl/PKGBUILD
@@ -2,16 +2,16 @@
 # Contributor: acxz <akashpatel2008 at yahoo dot com>
 
 pkgname=rccl
-pkgver=4.0.0
+pkgver=4.1.0
 pkgrel=1
 pkgdesc="ROCm Communication Collectives Library"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/rccl"
 license=('custom')
 depends=('hip' 'gtest')
-makedepends=('cmake' 'python')
+makedepends=('cmake' 'python' 'gmock')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
-sha256sums=('0632a15b3d6b5981c05377cf4aeb51546f4c4901fd7c37fb0c98071851ad531a')
+sha256sums=('88ec9b43c31cb054fe6aa28bcc0f4b510213635268f951939d6980eee5bb3680')
 _dirname="$(basename $url)-$(basename ${source[0]} .tar.gz)"
 
 build() {


### PR DESCRIPTION
Adding gmock to the build deps for rccl fixes the following error I got when building from a clean chroot (guessing this is the error #593 is complaining about)

```
CMake Error at /usr/lib64/cmake/GTest/GTestTargets.cmake:112 (message):
  The imported target "GTest::gmock" references the file

     "/usr/lib/libgmock.so.1.10.0"

  but this file does not exist.  Possible reasons include:
...
```

\+ update rccl release version