### PR TITLE
rocm-gdb: added flex depedency

### DIFF
--- a/rocm-gdb/.SRCINFO
+++ b/rocm-gdb/.SRCINFO
@@ -5,6 +5,7 @@ pkgbase = rocm-gdb
 	url = https://github.com/ROCm-Developer-Tools/ROCgdb
 	arch = x86_64
 	license = GPL
+	makedepends = flex
 	makedepends = texinfo
 	depends = rocm-dbgapi
 	depends = python

--- a/rocm-gdb/PKGBUILD
+++ b/rocm-gdb/PKGBUILD
@@ -1,4 +1,6 @@
-# Maintainer Torsten Keßler <t dot kessler at posteo dot de>
+# Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
+# Contributor: <pellegrinoprevete at gmail dot com>
+
 pkgname=rocm-gdb
 pkgver=4.2.0
 pkgrel=1
@@ -7,7 +9,7 @@ arch=('x86_64')
 url='https://github.com/ROCm-Developer-Tools/ROCgdb'
 license=('GPL')
 depends=('rocm-dbgapi' 'python' 'guile2.0' 'ncurses' 'expat' 'xz' 'zlib' 'mpfr' 'source-highlight' 'babeltrace')
-makedepends=('texinfo')
+makedepends=('flex' 'texinfo')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
 sha256sums=('4bc579584a1f8614111e7e44d8aa1c6d5d06be3f5db055aba2cf1abc140122ac')
 _dirname="$(basename "$url")-$(basename "${source[0]}" ".tar.gz")"


### PR DESCRIPTION
It seems like it's required to build it.