### PR TITLE
Fix #641: Use environment variables to specify which gfx targets to compile

### DIFF
--- a/hip-runtime-amd/PKGBUILD
+++ b/hip-runtime-amd/PKGBUILD
@@ -46,7 +46,8 @@ build() {
   -DROCCLR_PATH="$srcdir/$_dirrocclr" \
   -DHIP_PLATFORM=amd \
   -DOFFLOAD_ARCH_STR='' \
-  -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip
+  -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip \
+  -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
 
   make
 }

--- a/hipcub/PKGBUILD
+++ b/hipcub/PKGBUILD
@@ -22,7 +22,8 @@ build() {
   CXXFLAGS="${CXXFLAGS} -fcf-protection=none" \
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr
+        -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
 }
 
 package() {

--- a/hipfft/PKGBUILD
+++ b/hipfft/PKGBUILD
@@ -21,7 +21,8 @@ build() {
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DBUILD_CLIENTS_SAMPLES=OFF \
-        -DBUILD_CLIENTS_TESTS=OFF
+        -DBUILD_CLIENTS_TESTS=OFF \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
   make
 }
 

--- a/rccl/PKGBUILD
+++ b/rccl/PKGBUILD
@@ -24,7 +24,8 @@ build() {
   cmake -B build -Wno-dev \
         -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DBUILD_TESTS=OFF
+        -DBUILD_TESTS=OFF \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
 
   make -C build
 }

--- a/rocalution/PKGBUILD
+++ b/rocalution/PKGBUILD
@@ -20,7 +20,8 @@ build() {
   CXXFLAGS="${CXXFLAGS} -fcf-protection=none" \
   cmake -B build \
         -S "$_dirname" \
-        -DROCM_PATH=/opt/rocm
+        -DROCM_PATH=/opt/rocm \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
   make -C build
 }
 

--- a/rocblas/PKGBUILD
+++ b/rocblas/PKGBUILD
@@ -37,7 +37,8 @@ build() {
         -DBUILD_CLIENTS_TESTS=OFF \
         -DBUILD_CLIENTS_BENCHMARKS=OFF \
         -DBUILD_CLIENTS_SAMPLES=OFF \
-        -DBUILD_TESTING=OFF
+        -DBUILD_TESTING=OFF \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
 
   make -C build
 }

--- a/rocfft/PKGBUILD
+++ b/rocfft/PKGBUILD
@@ -23,7 +23,8 @@ build() {
   cmake -B build \
         -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DCMAKE_CXX_COMPILER=hipcc
+        -DCMAKE_CXX_COMPILER=hipcc \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
   make -C build
 }
 

--- a/rocrand/PKGBUILD
+++ b/rocrand/PKGBUILD
@@ -24,7 +24,8 @@ build() {
   CXXFLAGS="${CXXFLAGS} -fcf-protection=none" \
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DBUILD_TEST=OFF
+        -DBUILD_TEST=OFF \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
   make
 }
 

--- a/rocsolver/PKGBUILD
+++ b/rocsolver/PKGBUILD
@@ -28,7 +28,8 @@ build() {
     CXXFLAGS="${CXXFLAGS} -fcf-protection=none" \
     cmake   -B build \
             -S "$_dirname" \
-            -DCMAKE_INSTALL_PREFIX=/opt/rocm
+            -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+            -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
     make -C build
 }
 

--- a/rocsparse/PKGBUILD
+++ b/rocsparse/PKGBUILD
@@ -23,7 +23,8 @@ build() {
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -Drocprim_DIR=/opt/rocm/rocprim/rocprim/lib/cmake/rocprim \
-        -DBUILD_CLIENTS_SAMPLES=OFF
+        -DBUILD_CLIENTS_SAMPLES=OFF \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
   make
 }
 

--- a/rocthrust/PKGBUILD
+++ b/rocthrust/PKGBUILD
@@ -22,7 +22,8 @@ build() {
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
-        -DBUILD_TEST=OFF
+        -DBUILD_TEST=OFF \
+        -DAMDGPU_TARGETS=${AMDGPU_TARGETS}
 }
 
 package() {


### PR DESCRIPTION
This PR adds the additional line `-DAMDGPU_TARGETS=${AMDGPU_TARGETS}` to each of the cmake commands to enable specifying the target to compile for using an environment variable, and otherwise defaults to compiling all targets. This saves a significant amount of time and binary size for people compiling on their own machines, since they can now only compile for their particular GPU target.

Resolves #641 