### PR TITLE
upgpkg: rocm-core 5.0.1-1

### DIFF
--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-core
 	pkgdesc = AMD ROCm core package
-	pkgver = 4.5.2
+	pkgver = 5.0.1
 	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/
 	arch = x86_64

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 
 pkgname=rocm-core
-pkgver=4.5.2
+pkgver=5.0.1
 pkgrel=1
 pkgdesc='AMD ROCm core package'
 arch=('x86_64')
@@ -13,11 +13,11 @@ sha256sums=()
 
 package() {
   install -Dm644 /dev/stdin "$pkgdir/opt/rocm/.info/version" <<-EOF
-4.5.2-164
+5.0.1-59
 EOF
-  install -Dm644 /dev/stdin "$pkgdir/opt/rocm/include/rocm/rocm_version.h" <<-EOF
-#define ROCM_VERSION_MAJOR   4
-#define ROCM_VERSION_MINOR   5
-#define ROCM_VERSION_PATCH   2
+  install -Dm644 /dev/stdin "$pkgdir/opt/rocm/include/rocm_version.h" <<-EOF
+#define ROCM_VERSION_MAJOR   5
+#define ROCM_VERSION_MINOR   0
+#define ROCM_VERSION_PATCH   1
 EOF
 }


### PR DESCRIPTION
fix rocm_version.h path to match upstream/deb package

This is actually needed for building `python-pytorch-rocm` correctly.