### PR TITLE
upgpkg: mivisionx 5.1.0-1

### DIFF
--- a/mivisionx/.SRCINFO
+++ b/mivisionx/.SRCINFO
@@ -1,20 +1,19 @@
 pkgbase = mivisionx
 	pkgdesc = Set of comprehensive computer vision and machine intelligence libraries, utilities, and applications bundled into a single toolkit
-	pkgver = 3.10.0
+	pkgver = 5.1.0
 	pkgrel = 1
 	url = https://gpuopen-professionalcompute-libraries.github.io/MIVisionX/
 	arch = x86_64
 	license = MIT
 	makedepends = cmake
-	depends = rocm
+	depends = rocm-core
 	depends = rocm-cmake
 	depends = miopengemm
 	depends = miopen
 	depends = protobuf
 	depends = opencv
-	depends = ffmpeg
-	source = mivisionx-3.10.0.tar.gz::https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/archive/rocm-3.10.0.tar.gz
-	sha256sums = 8a67fae77a05ef60a501e64a572a7bd2ccb9243518b1414112ccd1d1f78d08c8
+	depends = ffmpeg4.4
+	source = mivisionx-5.1.0.tar.gz::https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/archive/rocm-5.1.0.tar.gz
+	sha256sums = e082415cc2fb859c53a6d6e5d72ca4529f6b4d56a4abe274dc374faaa5910513
 
 pkgname = mivisionx
-

--- a/mivisionx/PKGBUILD
+++ b/mivisionx/PKGBUILD
@@ -1,22 +1,26 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
+# Contributer: JP-Ellis <josh@jpellis.me>
+
 pkgname=mivisionx
-pkgver=3.10.0
+pkgver=5.1.0
 pkgrel=1
-pkgdesc="Set of comprehensive computer vision and machine intelligence
-libraries, utilities, and applications bundled into a single toolkit"
+pkgdesc="Set of comprehensive computer vision and machine intelligence libraries, utilities, and applications bundled into a single toolkit"
 arch=('x86_64')
 url="https://gpuopen-professionalcompute-libraries.github.io/MIVisionX/"
 license=('MIT')
-depends=('rocm' 'rocm-cmake' 'miopengemm' 'miopen' 'protobuf' 'opencv' 'ffmpeg')
+depends=('rocm-core' 'rocm-cmake' 'miopengemm' 'miopen' 'protobuf' 'opencv' 'ffmpeg4.4')
 makedepends=('cmake')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/archive/rocm-$pkgver.tar.gz")
-sha256sums=('8a67fae77a05ef60a501e64a572a7bd2ccb9243518b1414112ccd1d1f78d08c8')
+sha256sums=('e082415cc2fb859c53a6d6e5d72ca4529f6b4d56a4abe274dc374faaa5910513')
 
 build() {
   mkdir -p "$srcdir/build"
   cd "$srcdir/build"
 
-  cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/mivisionx \
+  export CXXFLAGS="${CXXFLAGS} -fcf-protection=none -fPIC -isystem /usr/include/ffmpeg4.4"
+
+  cmake -DBACKEND=HIP \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm/mivisionx \
         "$srcdir/MIVisionX-rocm-$pkgver"
   make
 }
@@ -29,7 +33,8 @@ package() {
   # add links
   install -d "$pkgdir/usr/bin"
   local _fn
-  for _fn in mivisionx; do
+  for _file in bin/* ; do
+    _fn="$(basename -- $_file)"
     ln -s "/opt/rocm/mivisionx/bin/$_fn" "$pkgdir/usr/bin/$_fn"
   done
 }

--- a/mivisionx/PKGBUILD
+++ b/mivisionx/PKGBUILD
@@ -1,4 +1,5 @@
-# Maintainer: acxz <akashpatel2008 at yahoo dot com>
+# Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
+# Contributor: acxz <akashpatel2008 at yahoo dot com>
 # Contributer: JP-Ellis <josh@jpellis.me>
 
 pkgname=mivisionx


### PR DESCRIPTION
MIVisionX does not yet work with FFMpeg 5.0; however FFMpeg 4.4 is available from the Arch repositories (it is a dependency for Firefox, OpenCV, VLC, Blender, among other).

Fixes: #429
Fixes: #597
Patches: #677 