### PR TITLE
upgpkg: miopen-hip/opencl 5.1.0-1

### DIFF
--- a/miopen-hip/.SRCINFO
+++ b/miopen-hip/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = miopen-hip
 	pkgdesc = AMD's Machine Intelligence Library (HIP backend)
-	pkgver = 4.5.2
+	pkgver = 5.1.0
 	pkgrel = 1
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
@@ -8,12 +8,17 @@ pkgbase = miopen-hip
 	makedepends = cmake
 	makedepends = rocm-cmake
 	makedepends = miopengemm
+	makedepends = sqlite
+	makedepends = boost>=1.78
 	depends = rocblas
 	depends = rocm-clang-ocl
 	depends = hip
+	depends = rocm-llvm-mlir
 	provides = miopen
 	conflicts = miopen
-	source = miopen-hip-4.5.2.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-4.5.2.tar.gz
-	sha256sums = cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc
+	source = miopen-hip-5.1.0.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-5.1.0.tar.gz
+	source = https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1490.patch
+	sha256sums = bb50201334d68addf153b84b88ab803027c4913d71bdbda6f5ccde3f672f6fdd
+	sha256sums = 35936708253212ddeb0b0c96344c85fb8455bd48037d8d25ab635adbbb97c263
 
 pkgname = miopen-hip

--- a/miopen-hip/PKGBUILD
+++ b/miopen-hip/PKGBUILD
@@ -3,36 +3,59 @@
 # Contributor: JP-Ellis <josh@jpellis.me>
 
 pkgname=miopen-hip
-pkgver=4.5.2
+pkgver=5.1.0
 pkgrel=1
 pkgdesc="AMD's Machine Intelligence Library (HIP backend)"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
 license=('MIT')
-depends=('rocblas' 'rocm-clang-ocl' 'hip')
-makedepends=('cmake' 'rocm-cmake' 'miopengemm')
+depends=('rocblas' 'rocm-clang-ocl' 'hip' 'rocm-llvm-mlir')
+makedepends=('cmake' 'rocm-cmake' 'miopengemm' 'sqlite' 'boost>=1.78')
 provides=('miopen')
 conflicts=('miopen')
-source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
-sha256sums=('cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz"
+       "https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1490.patch")
+sha256sums=('bb50201334d68addf153b84b88ab803027c4913d71bdbda6f5ccde3f672f6fdd'
+            '35936708253212ddeb0b0c96344c85fb8455bd48037d8d25ab635adbbb97c263')
 _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+
+prepare() {
+  cd "$_dirname"
+
+  # -fcf-protection is not supported by HIP, see
+  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-5.1.x/docs/markdown/clang_options.md
+  # -fPIC fixes linking errors.
+  export CC=/opt/rocm/llvm/bin/clang
+  export CXX=/opt/rocm/llvm/bin/clang++
+  export CXXFLAGS="${CXXFLAGS} -fcf-protection=none -fPIC"
+
+  # We can use the system SQLite and Boost
+  msg2 "Building dependencies"
+  sed -i 's|^sqlite|#\0|' {,min-}requirements.txt
+  sed -i 's|^boost|#\0|' {,min-}requirements.txt
+  sed -i 's|^ROCmSoftwarePlatform/llvm-project-mlir|#\0|' {,min-}requirements.txt
+  ./install_deps.cmake --minimum --prefix "$srcdir/deps"
+
+  msg2 "Patching files"
+  for p in $srcdir/*.patch ; do
+    patch -p1 < $p
+  done
+}
 
 build() {
   cd "$_dirname"
 
   # -fcf-protection is not supported by HIP, see
-  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.5.x/docs/markdown/clang_options.md
+  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-5.1.x/docs/markdown/clang_options.md
   # -fPIC fixes linking errors with boost.
+  export CC=/opt/rocm/llvm/bin/clang
   export CXX=/opt/rocm/llvm/bin/clang++
   export CXXFLAGS="${CXXFLAGS} -fcf-protection=none -fPIC"
 
-  cmake -P install_deps.cmake \
-        --minimum --prefix "$srcdir/deps"
-
   cmake -B build -Wno-dev \
         -DMIOPEN_BACKEND=HIP \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DCMAKE_PREFIX_PATH="$srcdir/deps"
+        -DCMAKE_PREFIX_PATH="$srcdir/deps" \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm
 
   make -C build
 }

--- a/miopen-opencl/.SRCINFO
+++ b/miopen-opencl/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = miopen-opencl
 	pkgdesc = AMD's Machine Intelligence Library (OpenCL backend)
-	pkgver = 4.5.2
+	pkgver = 5.1.0
 	pkgrel = 1
 	url = https://github.com/ROCmSoftwarePlatform/MIOpen
 	arch = x86_64
@@ -9,12 +9,17 @@ pkgbase = miopen-opencl
 	makedepends = rocm-cmake
 	makedepends = cmake
 	makedepends = miopengemm
+	makedepends = sqlite
+	makedepends = boost>=1.78
 	depends = ocl-icd
 	depends = rocblas
 	depends = rocm-llvm
+	depends = rocm-llvm-mlir
 	provides = miopen
 	conflicts = miopen
-	source = miopen-opencl-4.5.2.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-4.5.2.tar.gz
-	sha256sums = cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc
+	source = miopen-opencl-5.1.0.tar.gz::https://github.com/ROCmSoftwarePlatform/MIOpen/archive/rocm-5.1.0.tar.gz
+	source = https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1490.patch
+	sha256sums = bb50201334d68addf153b84b88ab803027c4913d71bdbda6f5ccde3f672f6fdd
+	sha256sums = 35936708253212ddeb0b0c96344c85fb8455bd48037d8d25ab635adbbb97c263
 
 pkgname = miopen-opencl

--- a/miopen-opencl/PKGBUILD
+++ b/miopen-opencl/PKGBUILD
@@ -1,39 +1,61 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 # Contributor: acxz <akashpatel at yahoo dot com>
+# Contributor: JP-Ellis <josh@jpellis.me>
 
 pkgname=miopen-opencl
-pkgver=4.5.2
+pkgver=5.1.0
 pkgrel=1
 pkgdesc="AMD's Machine Intelligence Library (OpenCL backend)"
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/MIOpen"
 license=('MIT')
-depends=('ocl-icd' 'rocblas' 'rocm-llvm')
-makedepends=('opencl-headers' 'rocm-cmake' 'cmake' 'miopengemm')
+depends=('ocl-icd' 'rocblas' 'rocm-llvm' 'rocm-llvm-mlir')
+makedepends=('opencl-headers' 'rocm-cmake' 'cmake' 'miopengemm' 'sqlite' 'boost>=1.78')
 provides=('miopen')
 conflicts=('miopen')
-source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
-sha256sums=('cb49bdf215ed9881755239b6312d72f829c1a0edf510e6d1fbb206c41f5406fc')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz"
+       "https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1490.patch")
+sha256sums=('bb50201334d68addf153b84b88ab803027c4913d71bdbda6f5ccde3f672f6fdd'
+            '35936708253212ddeb0b0c96344c85fb8455bd48037d8d25ab635adbbb97c263')
 _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+
+prepare() {
+  cd "$_dirname"
+
+  # -fcf-protection is not supported by HIP, see
+  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-5.1.x/docs/markdown/clang_options.md
+  # -fPIC fixes linking errors.
+  export CC=/opt/rocm/llvm/bin/clang
+  export CXX=/opt/rocm/llvm/bin/clang++
+  export CXXFLAGS="${CXXFLAGS} -fcf-protection=none -fPIC"
+
+  # We can use the system SQLite and Boost
+  msg2 "Building dependencies"
+  sed -i 's|^sqlite|#\0|' {,min-}requirements.txt
+  sed -i 's|^boost|#\0|' {,min-}requirements.txt
+  sed -i 's|^ROCmSoftwarePlatform/llvm-project-mlir|#\0|' {,min-}requirements.txt
+  ./install_deps.cmake --minimum --prefix "$srcdir/deps"
+
+  msg2 "Patching files"
+  for p in $srcdir/*.patch ; do
+    patch -p1 < $p
+  done
+}
 
 build() {
   cd "$_dirname"
 
   # -fcf-protection is not supported by HIP, see
-  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.5.x/docs/markdown/clang_options.md
+  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-5.1.x/docs/markdown/clang_options.md
   # -fPIC fixes linking errors with boost.
+  export CC=/opt/rocm/llvm/bin/clang
   export CXX=/opt/rocm/llvm/bin/clang++
   export CXXFLAGS="${CXXFLAGS} -fcf-protection=none -fPIC"
 
-  cmake -P install_deps.cmake \
-        --minimum --prefix "$srcdir/deps"
-
-  CXX=/opt/rocm/llvm/bin/clang++ \
   cmake -B build -Wno-dev \
         -DMIOPEN_BACKEND=OpenCL \
-        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-        -DCMAKE_PREFIX_PATH=/opt/rocm \
-        -DCMAKE_PREFIX_PATH="$srcdir/deps"
+        -DCMAKE_PREFIX_PATH="$srcdir/deps" \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm
 
   make -C build
 }

--- a/rocm-llvm-mlir/.SRCINFO
+++ b/rocm-llvm-mlir/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = rocm-llvm-mlir
+	pkgdesc = Radeon Open Compute - LLVM Multi-Level IR Compiler Framework
+	pkgver = 5.1
+	pkgrel = 1
+	url = https://github.com/ROCmSoftwarePlatform/llvm-project-mlir
+	arch = x86_64
+	license = custom:Apache 2.0 with LLVM Exception
+	makedepends = cmake
+	makedepends = sqlite
+	depends = rocm-llvm
+	source = https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/release/rocm-5.1.tar.gz
+	sha256sums = 7bc1eba4af74a4884efcf1cc73933efd7d8bc97445bf2a2e441d4db4ed624c4f
+
+pkgname = rocm-llvm-mlir

--- a/rocm-llvm-mlir/PKGBUILD
+++ b/rocm-llvm-mlir/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: JP-Ellis <josh@jpellis.me>
+
+pkgname=rocm-llvm-mlir
+pkgdesc="Radeon Open Compute - LLVM Multi-Level IR Compiler Framework"
+pkgver=5.1
+pkgrel=1
+arch=('x86_64')
+url="https://github.com/ROCmSoftwarePlatform/llvm-project-mlir"
+license=('custom:Apache 2.0 with LLVM Exception')
+depends=("rocm-llvm")
+makedepends=("cmake" "sqlite")
+source=("https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/release/rocm-5.1.tar.gz")
+sha256sums=('7bc1eba4af74a4884efcf1cc73933efd7d8bc97445bf2a2e441d4db4ed624c4f')
+_dirname="$(basename "$url")-release-$(basename "${source[0]}" .tar.gz)"
+
+build() {
+  # -fcf-protection is not supported by HIP, see
+  # https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.5.x/docs/markdown/clang_options.md
+  # -fPIC fixes linking.
+  export CXXFLAGS="${CXXFLAGS} -fcf-protection=none -fPIC"
+
+  cmake -S "$_dirname" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DMLIR_MIOPEN_SQLITE_ENABLED=On \
+    -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
+    -DCMAKE_INSTALL_PREFIX='/opt/rocm' \
+    -DBUILD_FAT_LIBMLIRMIOPEN=1
+
+  make
+}
+
+package() {
+  make DESTDIR="$pkgdir/" install
+
+  cd "$_dirname"
+  install -Dm644 mlir/LICENSE.TXT "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+# vim:set ts=2 sw=2 et:

--- a/rocm-llvm-mlir/PKGBUILD
+++ b/rocm-llvm-mlir/PKGBUILD
@@ -1,4 +1,6 @@
-# Maintainer: JP-Ellis <josh@jpellis.me>
+# Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
+# Contributor: acxz <akashpatel at yahoo dot com>
+# Contributor: JP-Ellis <josh@jpellis.me>
 
 pkgname=rocm-llvm-mlir
 pkgdesc="Radeon Open Compute - LLVM Multi-Level IR Compiler Framework"


### PR DESCRIPTION
There a few notable changes here:

- Instead of building Boost, the system versions are being used. This has become   possible since boostorg/config#393 which is included in Boost 1.78. The fix   relies in `HIP_VERSION` being defined which unfortunately is not always the case (and I am as yet unsure why). As a temporary workaround, the nine   problematic files are manually patched with a `#include <hip/hip_version.h>`. This is not an issue with the OpenCL version.
- I have similarly built against the system version of Half and SQLite. It appears there are no issues due to this.
- I have also tried removing the dependency `ROCmSoftwarePlatform/llvm-project-mlir` and everything compiles fine. I am unsure whether other ROCm packages provide what is necessary or not.
- I have been encountering an issue when compiling `build/kernel.cpp` with the HIP compiler. I do not know why, but disabling optimizations for that file works.

I will mark this pull request as a draft for now until the points above can be discussed.  Update: I am unable to mark it as a draft... someone with write access to rocm-arch needs to do it.

Patches: #676