### PR TITLE
clean up linewidth, rec paru, update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 # ROCm for Arch Linux
-This repository hosts a collection of [Arch Linux](https://www.archlinux.org/) [PKGBUILDs](https://wiki.archlinux.org/index.php/PKGBUILD) for the [AMD ROCm Platform](https://rocmdocs.amd.com/en/latest/).
-These scripts implement a great portion of the stack, ranging from low-level interfaces, over compilers to high-level application librariers.
+This repository hosts a collection of [Arch Linux](https://www.archlinux.org/)
+[PKGBUILDs](https://wiki.archlinux.org/index.php/PKGBUILD) for the
+[AMD ROCm Platform](https://www.amd.com/en/graphics/servers-solutions-rocm).
+These scripts implement a great portion of the stack, ranging from low-level
+interfaces, over compilers to high-level application librariers.
 
 ## Installation
-The Arch Linux packages for ROCm are available on the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
-Since many packages will be installed, it is recommended to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers)
-like [`yay`](https://aur.archlinux.org/packages/yay/).
+The Arch Linux packages for ROCm are available on the
+[AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository).
+Since many packages will be installed, it is recommended to use an
+[AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers)
+like [`paru`](https://aur.archlinux.org/packages/paru/).
 
-It is also recommended to use the [`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu) binary repository as it will
-greatly speed up your installation time.
+It is also recommended to use the
+[`arch4edu`](https://wiki.archlinux.org/index.php/Unofficial_user_repositories#arch4edu)
+binary repository as it will greatly speed up your installation time.
 For directions see [Add arch4edu to your Archlinux](https://github.com/arch4edu/arch4edu/wiki/Add-arch4edu-to-your-Archlinux).
 > **WARNING** Currently, `arch4edu` is out of sync see [this discussion](https://github.com/rocm-arch/rocm-arch/issues/642#issuecomment-1002910838).
 
 To install ROCm, use
 ```bash
-yay -S rocm-hip-sdk rocm-opencl-sdk
+paru -S rocm-hip-sdk rocm-opencl-sdk
 ```
-which includes the low-level components and compilers, utilities like `rocminfo` and GPU-accelerated math libraries. See the [documentation](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation_new.html#packages-in-rocm-programming-models) for an overview on the available meta packages.
+which includes the low-level components and compilers, utilities like `rocminfo`
+and GPU-accelerated math libraries. See the
+[documentation](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation_new.html#meta-packages-in-rocm-programming-models)
+for an overview on the available meta packages.
 > **WARNING** It is strongly recommended to remove all ROCm components when updating to a new release.
-> Otherwise, building the packages with `yay` may have unwanted side effects resulting in build errors.
+> Otherwise, building the packages with `paru` may have unwanted side effects resulting in build errors.
 > If it's a small release with only a few updated packages, consider building them in a [clean chroot](https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_clean_chroot).
 >
 > One way to mitigate these issues is to use the binary versions of the packages provided by arch4edu.
@@ -26,7 +35,7 @@ which includes the low-level components and compilers, utilities like `rocminfo`
 To speed up compilation of application libraries like `rocblas` or `rocfft` export `AMDGPU_TARGETS`
 and set it to the architecture name of your GPU. To find out this name, install `rocminfo`,
 ```bash
-yay -S rocminfo
+paru -S rocminfo
 ```
 and call
 ```bash
@@ -40,18 +49,30 @@ for VEGA 56/64 the output is
 Hence, you have to set `AMDGPU_TARGETS` to `gfx900`.
 
 For additional installation configuration, such as adding a user to the `video`
-group, we refer to AMD's [installation guide](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html).
+group, we refer to AMD's
+[installation guide](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation_new.html#setting-permissions-for-groups).
 
 To uninstall, use the following command:
 ```bash
-yay -R rocm-hip-sdk rocm-opencl-sdk
+paru -R rocm-hip-sdk rocm-opencl-sdk
 ```
 
-For more helpful tips see the ArchWiki entry on ROCm, [here](https://wiki.archlinux.org/index.php/GPGPU#ROCm).
+For more helpful tips see the ArchWiki entry on ROCm,
+[here](https://wiki.archlinux.org/index.php/GPGPU#ROCm).
+
+## Discussions/Support/Issues
+For general concerns/comments/support we use
+[Discussions](https://github.com/rocm-arch/rocm-arch/discussions).
+If you have issues specific to your setup or are having difficulties
+getting something to work, feel free to post there.
+
+Use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report
+problems with the AUR packages.
 
 ## Contributing
-Your contribution is always welcome. Use the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues) to report problems with the AUR packages.
-Optimally, you open a pull request that solves your problem.
+Your contribution is always welcome. Before making a pull request, please open
+an issue at the [issue tracker](https://github.com/rocm-arch/rocm-arch/issues)
+to report the problem with build/error logs.
 For most packages, you have to update `pkgver` and `sha256sums`. Before you commit your changes you will need to generate `.SRCINFO` from the updated `PKGBUILD`:
 ```bash
 makepkg --printsrcinfo > .SRCINFO


### PR DESCRIPTION
Just some readme cleanup.

I have also decided to recommend paru over yay. As paru now has devtool capabilities, i.e. you can build AUR packages into chroots directly with paru, (`paru -Syu --chroot`). See: https://www.reddit.com/r/archlinux/comments/tkeuy5/using_paru_u_chroot_to_build_a_pkgbuild_in_a/

Eventually, we may want to point users to using the paru chroot functionality as well in the readme. Or maybe the links to building in chroot should have that information.