### PR TITLE
[rocminfo] Install rocm_agent_enumerator

### DIFF
--- a/rocminfo/.SRCINFO
+++ b/rocminfo/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocminfo
 	pkgdesc = ROCm info tools - rocm_agent_enumerator
 	pkgver = 5.0.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/RadeonOpenCompute/rocminfo
 	arch = x86_64
 	license = custom:NCSAOSL

--- a/rocminfo/PKGBUILD
+++ b/rocminfo/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=rocminfo
 pkgver=5.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc='ROCm info tools - rocm_agent_enumerator'
 arch=('x86_64')
 url='https://github.com/RadeonOpenCompute/rocminfo'
@@ -31,4 +31,5 @@ package() {
   DESTDIR="$pkgdir" make install
   mkdir -p "$pkgdir/usr/bin"
   ln -st "$pkgdir/usr/bin" /opt/rocm/bin/rocminfo
+  ln -st "$pkgdir/usr/bin" /opt/rocm/bin/rocm_agent_enumerator
 }


### PR DESCRIPTION
The executable `rocm_agent_enumerator` is installed within `/opt/rocm/`, but is
not linked over into `/usr/bin`.