### PR TITLE
upgpkg: rocm-core 5.1.0-1

### DIFF
--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -4,5 +4,7 @@ pkgbase = rocm-core
 	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/
 	arch = x86_64
+	source = rocm-core-5.1.0.deb::https://repo.radeon.com/rocm/apt/5.1/pool/main/r/rocm-core/rocm-core_5.1.0.50100-36_amd64.deb
+	sha256sums = c019d97cfef8f8fd0d8b5bc24634dd05b40e9c9f8c69c4c2ba62b626c6dacd82
 
 pkgname = rocm-core

--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-core
 	pkgdesc = AMD ROCm core package
-	pkgver = 5.0.2
+	pkgver = 5.1.0
 	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/
 	arch = x86_64

--- a/rocm-core/CMakeLists.txt
+++ b/rocm-core/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.23)
+project(rocm-core)
+add_library(rocm-core SHARED rocm_version.c)
+set_target_properties(rocm-core PROPERTIES VERSION "1.0.${ROCM_VERSION}")
+find_path(ROCM_HEADER_DIR rocm_version.h)
+target_include_directories(rocm-core PUBLIC ${ROCM_HEADER_DIR})
+install(TARGETS rocm-core LIBRARY DESTINATION lib)

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -1,25 +1,45 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
+# Contributor: JP-Ellis <josh@jpellis.me>
 
 pkgname=rocm-core
-pkgver=5.1.0
+_pkgver_major=5
+_pkgver_minor=1
+_pkgver_patch=0
+_pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
+_pkgver_magic=36
+pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
 pkgdesc='AMD ROCm core package'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/'
 license=()
 depends=()
-source=()
+source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver%.*}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.$_pkgver_str-${_pkgver_magic}_amd64.deb"
+        "rocm_version.c"
+        "CMakeLists.txt")
+sha256sums=('c019d97cfef8f8fd0d8b5bc24634dd05b40e9c9f8c69c4c2ba62b626c6dacd82'
+            '976781c610ac766c91a1da3f3f1474595216f69a0fdcb8c966f1f94095ce947a'
+            'ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560')
 
-
-
-package() {
-  install -Dm644 /dev/stdin "$pkgdir/opt/rocm/.info/version" <<-EOF
-5.1.0-36
-EOF
-  install -Dm644 /dev/stdin "$pkgdir/opt/rocm/include/rocm_version.h" <<-EOF
-#define ROCM_VERSION_MAJOR   5
-#define ROCM_VERSION_MINOR   1
-#define ROCM_VERSION_PATCH   0
-EOF
+prepare() {
+  tar -xf data.tar.gz
 }
 
+build() {
+  cmake -B build \
+    -DROCM_VERSION=$_pkgver_str \
+    -DCMAKE_PREFIX_PATH="$srcdir/opt/rocm-${pkgver}" \
+    -DCMAKE_INSTALL_PREFIX=/opt/rocm
+
+  make -C build
+
+  sed -i "s|/opt/rocm-${pkgver}|/opt/rocm|g" opt/rocm-${pkgver}/lib/rocmmod
+}
+
+package() {
+  make DESTDIR="$pkgdir" -C build install
+  install -Dm644 opt/rocm-${pkgver}/.info/version "$pkgdir/opt/rocm/.info/version"
+  install -Dm644 opt/rocm-${pkgver}/include/rocm_version.h "$pkgdir/opt/rocm/include/rocm_version.h"
+  install -Dm644 opt/rocm-${pkgver}/lib/rocmmod "$pkgdir/opt/rocm/lib/rocmmod"
+  mkdir -p "$pkgdir/opt/rocm/lib/CMakeFiles/rocm-core.dir"
+}

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 
 pkgname=rocm-core
-pkgver=5.0.2
+pkgver=5.1.0
 pkgrel=1
 pkgdesc='AMD ROCm core package'
 arch=('x86_64')
@@ -9,15 +9,17 @@ url='https://rocmdocs.amd.com/en/latest/'
 license=()
 depends=()
 source=()
-sha256sums=()
+
+
 
 package() {
   install -Dm644 /dev/stdin "$pkgdir/opt/rocm/.info/version" <<-EOF
-5.0.2-72
+5.1.0-36
 EOF
   install -Dm644 /dev/stdin "$pkgdir/opt/rocm/include/rocm_version.h" <<-EOF
 #define ROCM_VERSION_MAJOR   5
-#define ROCM_VERSION_MINOR   0
-#define ROCM_VERSION_PATCH   2
+#define ROCM_VERSION_MINOR   1
+#define ROCM_VERSION_PATCH   0
 EOF
 }
+

--- a/rocm-core/rocm_version.c
+++ b/rocm-core/rocm_version.c
@@ -1,0 +1,10 @@
+#include "rocm_version.h"
+
+VerErrors getROCmVersion(unsigned int *Major, unsigned int *Minor,
+                         unsigned int *Patch) {
+  *Major = ROCM_VERSION_MAJOR;
+  *Minor = ROCM_VERSION_MINOR;
+  *Patch = ROCM_VERSION_PATCH;
+
+  return 0;
+}


### PR DESCRIPTION
I just want to note that [the upstream `.deb` release](https://repo.radeon.com/rocm/apt/5.1/pool/main/r/rocm-core/rocm-core_5.1.0.50100-36_amd64.deb) also has a more complex `rocm_version.h` and also include `librocm-core.so`.  Perhaps we should look to be similar?