### PR TITLE
upgpkg hip-runtime-nvidia 5.1.1-1

### DIFF
--- a/hip-runtime-nvidia/.SRCINFO
+++ b/hip-runtime-nvidia/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-runtime-nvidia
 	pkgdesc = Heterogeneous Interface for Portability ROCm
-	pkgver = 5.1.0
-	pkgrel = 2
+	pkgver = 5.1.1
+	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT
@@ -13,12 +13,12 @@ pkgbase = hip-runtime-nvidia
 	depends = rocm-llvm
 	provides = hip
 	conflicts = hip
-	source = hip-runtime-nvidia-5.1.0.tar.gz::https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-5.1.0.tar.gz
-	source = hip-runtime-nvidia-hipamd-5.1.0.tar.gz::https://github.com/ROCm-Developer-Tools/hipamd/archive/rocm-5.1.0.tar.gz
+	source = hip-runtime-nvidia-5.1.1.tar.gz::https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-5.1.1.tar.gz
+	source = hip-runtime-nvidia-hipamd-5.1.1.tar.gz::https://github.com/ROCm-Developer-Tools/hipamd/archive/rocm-5.1.1.tar.gz
 	source = nvcc.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/HIP/pull/2623.patch
 	source = git-hash.patch
-	sha256sums = 47e542183699f4005c48631d96f6a1fbdf27e07ad3402ccd7b5f707c2c602266
-	sha256sums = 77984854bfe00f938353fe4c7604d09967eaf5c609d05f1e6423d3c3dea86e61
+	sha256sums = c2400c98d87f72e7a879d167d9913bca778e66bc198518a0fdb345e3e50792f1
+	sha256sums = e2fb059841940a9ccf5d8b94e5022979796d93da2f049211fbd07e190d3e99e5
 	sha256sums = SKIP
 	sha256sums = 84cd40751e041edd48489eca59f1702bba08a402b25162e4cf061de45abc2bde
 

--- a/hip-runtime-nvidia/PKGBUILD
+++ b/hip-runtime-nvidia/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 # Contributor: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-runtime-nvidia
-pkgver=5.1.0
-pkgrel=2
+pkgver=5.1.1
+pkgrel=1
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
@@ -17,8 +17,8 @@ source=("$pkgname-$pkgver.tar.gz::$_hip/archive/rocm-$pkgver.tar.gz"
         "$pkgname-hipamd-$pkgver.tar.gz::$_hipamd/archive/rocm-$pkgver.tar.gz"
         "nvcc.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/HIP/pull/2623.patch"
         "git-hash.patch")
-sha256sums=('47e542183699f4005c48631d96f6a1fbdf27e07ad3402ccd7b5f707c2c602266'
-            '77984854bfe00f938353fe4c7604d09967eaf5c609d05f1e6423d3c3dea86e61'
+sha256sums=('c2400c98d87f72e7a879d167d9913bca778e66bc198518a0fdb345e3e50792f1'
+            'e2fb059841940a9ccf5d8b94e5022979796d93da2f049211fbd07e190d3e99e5'
             'SKIP'
             '84cd40751e041edd48489eca59f1702bba08a402b25162e4cf061de45abc2bde')
 _dirhip="$(basename "$_hip")-$(basename "${source[0]}" ".tar.gz")"
@@ -33,14 +33,15 @@ prepare() {
 }
 
 build() {
+  local cmake_args=(-DHIP_COMMON_DIR="$srcdir/$_dirhip" \
+                    -DHIP_PLATFORM=nvidia \
+                    -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip)
+
   # build fails if cmake and make are called from outside the build directory
   mkdir build && cd build
   cmake -Wno-dev \
   -S "$srcdir/$_dirhipamd" \
-  -DHIP_COMMON_DIR="$srcdir/$_dirhip" \
-  -DHIP_PLATFORM=nvidia \
-  -DCMAKE_INSTALL_PREFIX=/opt/rocm/hip \
-  -DCMAKE_HIP_ARCHITECTURES='sm_70;sm72;sm_75;sm_80;sm_86'
+  "${cmake_args[@]}"
 
   make
 }
@@ -59,6 +60,13 @@ package() {
 
   # clang from llvm-amdgpu may look for hipVersion in a different directory
   ln -s '/opt/rocm/hip/bin/.hipVersion' "$pkgdir/opt/rocm/bin/.hipVersion"
+  # Same holds for the HIP library
+  install -d "$pkgdir/opt/rocm/lib"
+  ln -s "/opt/rocm/hip/lib/libamdhip64.so" "$pkgdir/opt/rocm/lib/libamdhip64.so"
+
+  # Some packages search for hip includes in /opt/rocm/include
+  install -d "$pkgdir/opt/rocm/include"
+  ln -s "/opt/rocm/hip/include/hip" "$pkgdir/opt/rocm/include/hip"
 
   # CMake projects with language "HIP" look for hip config files in /opt/rocm/lib
   install -d "$pkgdir/opt/rocm/lib/cmake"


### PR DESCRIPTION
add missing links, use cmake_args format, CMAKE_HIP_ARCH... deprecated