### PR TITLE
upgpkg: rocm-llvm-mlir 5.2.0-1

### DIFF
--- a/rocm-llvm-mlir/.SRCINFO
+++ b/rocm-llvm-mlir/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-llvm-mlir
 	pkgdesc = Radeon Open Compute - LLVM Multi-Level IR Compiler Framework
-	pkgver = 5.1.3
+	pkgver = 5.2.0
 	pkgrel = 1
 	url = https://github.com/ROCmSoftwarePlatform/llvm-project-mlir
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = rocm-llvm-mlir
 	makedepends = python
 	depends = hip
 	options = !lto
-	source = rocm-llvm-mlir-5.1.3.tar.gz::https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/refs/tags/rocm-5.1.3.tar.gz
-	sha256sums = 936f92707ffe9a1973728503db6365bb7f14e5aeccfaef9f0924e54d25080c69
+	source = rocm-llvm-mlir-5.2.0.tar.gz::https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/refs/tags/rocm-5.2.0.tar.gz
+	sha256sums = 546121f203e7787d3501fbaf6673bdbeefbb39e0446b02c480454338362a1f01
 
 pkgname = rocm-llvm-mlir

--- a/rocm-llvm-mlir/PKGBUILD
+++ b/rocm-llvm-mlir/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=rocm-llvm-mlir
 pkgdesc="Radeon Open Compute - LLVM Multi-Level IR Compiler Framework"
-pkgver=5.1.3
+pkgver=5.2.0
 pkgrel=1
 arch=('x86_64')
 url="https://github.com/ROCmSoftwarePlatform/llvm-project-mlir"
@@ -12,7 +12,7 @@ license=('custom:Apache 2.0 with LLVM Exception')
 depends=("hip")
 makedepends=("cmake" "sqlite" "python")
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/rocm-$pkgver.tar.gz")
-sha256sums=('936f92707ffe9a1973728503db6365bb7f14e5aeccfaef9f0924e54d25080c69')
+sha256sums=('546121f203e7787d3501fbaf6673bdbeefbb39e0446b02c480454338362a1f01')
 options=(!lto)
 _dirname="$(basename $url)-$(basename ${source[0]} .tar.gz)"
 


### PR DESCRIPTION
fixes build error for `miopen-hip`
- update pkgver
- update checksums
- update .SRCINFO