### PR TITLE
upgpkg: hip-runtime-amd 5.2.0-4

### DIFF
--- a/hip-runtime-amd/.SRCINFO
+++ b/hip-runtime-amd/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hip-runtime-amd
 	pkgdesc = Heterogeneous Interface for Portability ROCm
 	pkgver = 5.2.0
-	pkgrel = 4
+	pkgrel = 5
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html
 	arch = x86_64
 	license = MIT
@@ -19,13 +19,15 @@ pkgbase = hip-runtime-amd
 	source = hip-runtime-amd-opencl-5.2.0.tar.gz::https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/archive/rocm-5.2.0.tar.gz
 	source = hip-runtime-amd-rocclr-5.2.0.tar.gz::https://github.com/ROCm-Developer-Tools/ROCclr/archive/rocm-5.2.0.tar.gz
 	source = hip-runtime-amd-hipamd-5.2.0.tar.gz::https://github.com/ROCm-Developer-Tools/hipamd/archive/rocm-5.2.0.tar.gz
-	source = config-path.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/hipamd/pull/32.patch
 	source = git-hash.patch::https://github.com/ROCm-Developer-Tools/hipamd/commit/56b32604729cca08bdcf00c7a69da8a75cc95b8a.patch
+	source = noinline.patch::https://github.com/ROCm-Developer-Tools/hipamd/commit/28009bc68faf2b4dd8fda91c99b0725e1b063a18.patch
+	source = config-path.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/hipamd/pull/32.patch
 	sha256sums = a6e0515d4d25865c037b546035df9c51f0882cd2700e759c266ff7e199f37c3a
 	sha256sums = 80f73387effdcd987a150978775a87049a976aa74f5770d4420847b004dd59f0
 	sha256sums = 37f5fce04348183bce2ece8bac1117f6ef7e710ca68371ff82ab08e93368bafb
 	sha256sums = 8774958bebc29a4b7eb9dc2d38808d79d9a24bf9c1f44e801ff99d2d5ba82240
-	sha256sums = SKIP
+	sha256sums = 3b0ec136c9bad206697087df0908922df705ec76085f57e36d0d15f52a5fd981
+	sha256sums = f45f2087ba3fab3ee3b9e65baefad604cd774611f3d433273afc1166d146e8ed
 	sha256sums = SKIP
 
 pkgname = hip-runtime-amd

--- a/hip-runtime-amd/PKGBUILD
+++ b/hip-runtime-amd/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: acxz <akashpatel2008 at yahoo dot com>
 pkgname=hip-runtime-amd
 pkgver=5.2.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Heterogeneous Interface for Portability ROCm"
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/HIP.html'
@@ -19,13 +19,15 @@ source=("$pkgname-$pkgver.tar.gz::$_hip/archive/rocm-$pkgver.tar.gz"
         "$pkgname-opencl-$pkgver.tar.gz::$_opencl/archive/rocm-$pkgver.tar.gz"
         "$pkgname-rocclr-$pkgver.tar.gz::$_rocclr/archive/rocm-$pkgver.tar.gz"
         "$pkgname-hipamd-$pkgver.tar.gz::$_hipamd/archive/rocm-$pkgver.tar.gz"
-        "config-path.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/hipamd/pull/32.patch"
-        "git-hash.patch::https://github.com/ROCm-Developer-Tools/hipamd/commit/56b32604729cca08bdcf00c7a69da8a75cc95b8a.patch")
+        "git-hash.patch::https://github.com/ROCm-Developer-Tools/hipamd/commit/56b32604729cca08bdcf00c7a69da8a75cc95b8a.patch"
+        "noinline.patch::https://github.com/ROCm-Developer-Tools/hipamd/commit/28009bc68faf2b4dd8fda91c99b0725e1b063a18.patch"
+        "config-path.patch::https://patch-diff.githubusercontent.com/raw/ROCm-Developer-Tools/hipamd/pull/32.patch")
 sha256sums=('a6e0515d4d25865c037b546035df9c51f0882cd2700e759c266ff7e199f37c3a'
             '80f73387effdcd987a150978775a87049a976aa74f5770d4420847b004dd59f0'
             '37f5fce04348183bce2ece8bac1117f6ef7e710ca68371ff82ab08e93368bafb'
             '8774958bebc29a4b7eb9dc2d38808d79d9a24bf9c1f44e801ff99d2d5ba82240'
-            'SKIP'
+            '3b0ec136c9bad206697087df0908922df705ec76085f57e36d0d15f52a5fd981'
+            'f45f2087ba3fab3ee3b9e65baefad604cd774611f3d433273afc1166d146e8ed'
             'SKIP')
 _dirhip="$(basename "$_hip")-$(basename "${source[0]}" ".tar.gz")"
 _diropencl="$(basename "$_opencl")-$(basename "${source[1]}" ".tar.gz")"
@@ -35,6 +37,7 @@ _dirhipamd="$(basename "$_hipamd")-$(basename "${source[3]}" ".tar.gz")"
 prepare() {
     cd "$_dirhipamd"
     patch -Np1 -i "$srcdir/git-hash.patch"
+    patch -Np1 -i "$srcdir/noinline.patch"
     patch -N   -i "$srcdir/config-path.patch"
 }
 
@@ -60,9 +63,6 @@ build() {
 
 package() {
   DESTDIR="$pkgdir" make -C build install
-
-  # https://github.com/ROCm-Developer-Tools/HIP/issues/2678
-  sed -i '/__noinline__/d' "$pkgdir/opt/rocm/include/hip/amd_detail/host_defines.h"
 
   # add links (hipconfig is for rocblas with tensile)
   install -d "$pkgdir/usr/bin"


### PR DESCRIPTION
use upstream patch for noinline

update patch for #782 