### PR TITLE
Also install rocm-core/rocm_version.h

### DIFF
--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = rocm-core
 	pkgdesc = AMD ROCm core package
 	pkgver = 5.2.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://docs.amd.com/
 	arch = x86_64
 	makedepends = cmake

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -8,7 +8,7 @@ _pkgver_patch=0
 _pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
 _pkgver_magic=65
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
-pkgrel=1
+pkgrel=2
 pkgdesc='AMD ROCm core package'
 arch=('x86_64')
 url='https://docs.amd.com/'
@@ -41,6 +41,7 @@ package() {
   make DESTDIR="$pkgdir" -C build install
   install -Dm644 opt/rocm-${pkgver}/.info/version "$pkgdir/opt/rocm/.info/version"
   install -Dm644 opt/rocm-${pkgver}/include/rocm_version.h "$pkgdir/opt/rocm/include/rocm_version.h"
+  install -Dm644 opt/rocm-${pkgver}/include/rocm-core/rocm_version.h "$pkgdir/opt/rocm/include/rocm-core/rocm_version.h"
   install -Dm644 opt/rocm-${pkgver}/lib/rocmmod "$pkgdir/opt/rocm/lib/rocmmod"
   mkdir -p "$pkgdir/opt/rocm/lib/CMakeFiles/rocm-core.dir"
 }


### PR DESCRIPTION
So rocm-core installs /opt/rocm/include/rocm_version.h which gives a deprecation warning and includes ``rocm-core/rocm_version.h``, this is not installed by the package. This header is used by pytorch, which is how I found the issue.

This change installs the missing header from the .deb