### PR TITLE
[WIP] Add support for gfx1031 (6700XT)

### DIFF
--- a/rocalution/PKGBUILD
+++ b/rocalution/PKGBUILD
@@ -11,14 +11,17 @@ depends=('hip' 'rocsparse' 'rocblas' 'rocprim' 'rocrand' 'openmp')
 makedepends=('cmake' 'rocm-cmake' 'git')
 _git='https://github.com/ROCmSoftwarePlatform/rocALUTION'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
-        "rocblas-rocsparse-include-path.patch::$_git/commit/8264818ab790c48f12df45e6dc90d504be72d690.patch")
+        "rocblas-rocsparse-include-path.patch::$_git/commit/8264818ab790c48f12df45e6dc90d504be72d690.patch"
+        "gfx1031.patch")
 sha256sums=('f246bd5b5d1b5821c29b566610a1c1d5c5cc361e0e5c373b8b04168b05e9b26f'
+            'SKIP'
             'SKIP')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 
 prepare() {
     cd "$_dirname"
     patch -Np1 -i "$srcdir/rocblas-rocsparse-include-path.patch"
+    patch -Np1 -i "$srcdir/gfx1031.patch"
 }
 
 build() {

--- a/rocalution/gfx1031.patch
+++ b/rocalution/gfx1031.patch
@@ -1,0 +1,13 @@
+diff --git a/src/base/hip/hip_utils.hpp b/src/base/hip/hip_utils.hpp
+index 550beb7..464d8da 100644
+--- a/src/base/hip/hip_utils.hpp
++++ b/src/base/hip/hip_utils.hpp
+@@ -206,7 +206,7 @@ namespace rocalution
+ 
+     __device__ int __llvm_amdgcn_readlane(int index, int offset) __asm("llvm.amdgcn.readlane");
+ 
+-#ifndef __gfx1030__
++#if !defined(__gfx1030__) && !defined(__gfx1031__)
+     template <unsigned int WFSIZE>
+     static __device__ __forceinline__ void wf_reduce_sum(int* sum)
+     {

--- a/rocblas/PKGBUILD
+++ b/rocblas/PKGBUILD
@@ -12,8 +12,10 @@ makedepends=('cmake' 'git' 'python' 'python-pip' 'python-virtualenv' 'python-pya
              'perl-file-which' 'msgpack-c' 'rocm-cmake' 'gcc-fortran')
 _rocblas='https://github.com/ROCmSoftwarePlatform/rocBLAS'
 source=("$pkgname-$pkgver.tar.gz::$_rocblas/archive/rocm-$pkgver.tar.gz"
-        "include-path.patch::https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/992429ff1d04195b10f9a3350668e180b34dbdb5.patch")
+        "include-path.patch::https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/992429ff1d04195b10f9a3350668e180b34dbdb5.patch"
+        "gfx1031.patch::https://github.com/littlewu2508/rocBLAS/commit/6c360dca36e8d6e691527b238d9a22f656ff3ade.patch")
 sha256sums=('6be804ba8d9e491a85063c220cd0ddbf3d13e3b481eee31041c35a938723f4c6'
+            'SKIP'
             'SKIP')
 options=(!lto)
 _dirname="$(basename "$_rocblas")-$(basename "${source[0]}" ".tar.gz")"
@@ -25,6 +27,7 @@ prepare() {
     # See https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/992429ff1d04195b10f9a3350668e180b34dbdb5
     cd "$_dirname"
     patch -Np1 -i "$srcdir/include-path.patch"
+    patch -Np1 -i "$srcdir/gfx1031.patch"
 }
 
 build() {
@@ -33,6 +36,8 @@ build() {
                     -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr
                     -DBUILD_WITH_TENSILE=ON
                     -DTensile_LIBRARY_FORMAT=yaml
+                    -Dtensile_fork="DorianRudolph"
+                    -Dtensile_tag="1eba330320cf798e8a37e3de332ad4480110a430"
                     -DTensile_CPU_THREADS="$_tensile_threads"
                     -DTensile_CODE_OBJECT_VERSION=V3
                     -DCMAKE_TOOLCHAIN_FILE=toolchain-linux.cmake


### PR DESCRIPTION
This may not (yet) be suitable for merging due downloading files from third-party repos, and I haven't tested everything yet. Specifically, I want to see if I can get pytorch working. But I can compile the `rocm-hip-sdk` and `rocm-opencl-sdk` with `AMDGPU_TARGETS="gfx1031"`, so I thought this may be of interest to fellow users of this chip.

This is based on applying the patches by @littlewu2508. See: https://github.com/RadeonOpenCompute/ROCm/issues/1714#issuecomment-1129650470 and PRs https://github.com/ROCmSoftwarePlatform/rocBLAS/pull/1251 and https://github.com/ROCmSoftwarePlatform/Tensile/pull/1511
The rocalution patch is mine, though I don't even know what that software does.