### PR TITLE
rocm-llvm-mlir: fix sha256sum and root dirname

### DIFF
--- a/rocm-llvm-mlir/.SRCINFO
+++ b/rocm-llvm-mlir/.SRCINFO
@@ -12,7 +12,7 @@ pkgbase = rocm-llvm-mlir
 	options = !lto
 	source = rocm-llvm-mlir-5.3.0.tar.gz::https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/refs/tags/rocm-5.3.0.tar.gz
 	source = llvm-project-mlir-fix-rpath-flags.patch::https://patch-diff.githubusercontent.com/raw/ROCmSoftwarePlatform/llvm-project-mlir/pull/688.patch
-	sha256sums = ee5093aad5459773c350205ef937a186a20994b42798106f8126b9914ad099a5
+	sha256sums = e8471a13cb39d33adff34730d3162adaa5d20f9544d61a6a94b39b9b5762ad6d
 	sha256sums = 7085543c8726b3b14cae675ecccef54847a2525af3a13d34d6e1d52d2a17907a
 
 pkgname = rocm-llvm-mlir

--- a/rocm-llvm-mlir/PKGBUILD
+++ b/rocm-llvm-mlir/PKGBUILD
@@ -13,10 +13,10 @@ depends=("hip")
 makedepends=("cmake" "sqlite" "python")
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/rocm-$pkgver.tar.gz"
         "llvm-project-mlir-fix-rpath-flags.patch::https://patch-diff.githubusercontent.com/raw/ROCmSoftwarePlatform/llvm-project-mlir/pull/688.patch")
-sha256sums=('ee5093aad5459773c350205ef937a186a20994b42798106f8126b9914ad099a5'
+sha256sums=('e8471a13cb39d33adff34730d3162adaa5d20f9544d61a6a94b39b9b5762ad6d'
             '7085543c8726b3b14cae675ecccef54847a2525af3a13d34d6e1d52d2a17907a')
 options=(!lto)
-_dirname="$(basename $url)-$(basename ${source[0]} .tar.gz)"
+_dirname="rocMLIR-rocm-${pkgver}"
 
 prepare() {
   cd "$_dirname"


### PR DESCRIPTION
I don't know why this broke, since it seems like the URL and hashes were updated together. I was able to get it building with these changes, though.

should resolve https://github.com/rocm-arch/rocm-arch/issues/863