### PR TITLE
rocfft: use absolute path to `hipcc` for `CMAKE_CXX_COMPILER`

### DIFF
--- a/rocfft/PKGBUILD
+++ b/rocfft/PKGBUILD
@@ -18,7 +18,7 @@ _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 
 build() {
   local cmake_args=(-DCMAKE_INSTALL_PREFIX=/opt/rocm
-                    -DCMAKE_CXX_COMPILER=hipcc)
+                    -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc)
   if [[ -n "$AMDGPU_TARGETS" ]]; then
       cmake_args+=(-DAMDGPU_TARGETS="$AMDGPU_TARGETS")
   fi


### PR DESCRIPTION
Fixes the following error if `$PATH` doesn't include `/opt/rocm/bin`
```
==> Starting build()...
-- The CXX compiler identification is unknown
-- The C compiler identification is GNU 12.2.0
CMake Error at CMakeLists.txt:47 (project):
  The CMAKE_CXX_COMPILER:

    hipcc

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```
Resolves #861 