### PR TITLE
Update: hsa-amd-aqlprofile-bin, rocm-core, rocm-hip-runtime

### DIFF
--- a/hsa-amd-aqlprofile-bin/.SRCINFO
+++ b/hsa-amd-aqlprofile-bin/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = hsa-amd-aqlprofile-bin
 	pkgdesc = AQLPROFILE library for AMD HSA runtime API extension support
-	pkgver = 5.2.3
+	pkgver = 5.3.0
 	pkgrel = 1
 	url = https://docs.amd.com/
 	arch = x86_64
 	license = EULA
 	provides = hsa-amd-aqlprofile
 	conflicts = hsa-amd-aqlprofile
-	source = hsa-amd-aqlprofile-bin-5.2.3.tar.gz::http://repo.radeon.com/rocm/apt/5.2.3/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50203-109_amd64.deb
-	sha256sums = ac94ead24a5ecfc9462b09ef647ac036333c856391571e9071e3263f1232dd71
+	source = hsa-amd-aqlprofile-bin-5.3.0.tar.gz::http://repo.radeon.com/rocm/apt/5.3/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50300-63~22.04_amd64.deb
+	sha256sums = 46635f4f019aba1c3a53665430b0de70b992700e852f08b36f54ff33ca7e3ec7
 
 pkgname = hsa-amd-aqlprofile-bin

--- a/hsa-amd-aqlprofile-bin/PKGBUILD
+++ b/hsa-amd-aqlprofile-bin/PKGBUILD
@@ -3,10 +3,10 @@
 
 pkgname=hsa-amd-aqlprofile-bin
 _pkgname=hsa-amd-aqlprofile
-pkgver=5.2.3
-_pkgver=5.2.3
+pkgver=5.3.0
+_pkgver=5.3
 pkgrel=1
-_debfile="hsa-amd-aqlprofile_1.0.0.50203-109_amd64.deb"
+_debfile="hsa-amd-aqlprofile_1.0.0.50300-63~22.04_amd64.deb"
 pkgdesc='AQLPROFILE library for AMD HSA runtime API extension support'
 arch=('x86_64')
 url='https://docs.amd.com/'
@@ -15,12 +15,12 @@ depends=()
 provides=('hsa-amd-aqlprofile')
 conflicts=('hsa-amd-aqlprofile')
 source=("$pkgname-$pkgver.tar.gz::http://repo.radeon.com/rocm/apt/${_pkgver}/pool/main/h/hsa-amd-aqlprofile/${_debfile}")
-sha256sums=('ac94ead24a5ecfc9462b09ef647ac036333c856391571e9071e3263f1232dd71')
+sha256sums=('46635f4f019aba1c3a53665430b0de70b992700e852f08b36f54ff33ca7e3ec7')
 
 package() {
   tar -C "$pkgdir" -xf data.tar.gz
   rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
   rename -- "${_pkgname#hsa}" '' "$pkgdir/opt/rocm/$_pkgname"
   find "$pkgdir" -type d -exec chmod 755 '{}' '+'
-  ln -sf "/opt/rocm/hsa/lib/libhsa-amd-aqlprofile64.so" "$pkgdir/opt/rocm/lib/libhsa-amd-aqlprofile64.so" 
+  ln -sf "/opt/rocm/hsa/lib/libhsa-amd-aqlprofile64.so" "$pkgdir/opt/rocm/lib/libhsa-amd-aqlprofile64.so.1"
 }

--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = rocm-core
 	pkgdesc = AMD ROCm core package
-	pkgver = 5.2.3
+	pkgver = 5.3.0
 	pkgrel = 1
 	url = https://docs.amd.com/
 	arch = x86_64
 	makedepends = cmake
-	source = rocm-core-5.2.3.deb::https://repo.radeon.com/rocm/apt/5.2.3/pool/main/r/rocm-core5.2.3/rocm-core5.2.3_5.2.3.50203-109_amd64.deb
+	source = rocm-core-5.3.0.deb::https://repo.radeon.com/rocm/apt/5.3/pool/main/r/rocm-core/rocm-core_5.3.0.50300-63~22.04_amd64.deb
 	source = rocm_version.c
 	source = CMakeLists.txt
-	sha256sums = 21582613891053208e854457d795a68b89a66b04d4fe79967635f6b83aace206
+	sha256sums = 9755a7a06f29529c675bdf516b79d52c8b46c1cb7b5a3749221a2de379f594ef
 	sha256sums = 23ded36e5cf003be491e09e56b10982efb585b6bb93ae18884a8a160f0d9cae0
 	sha256sums = ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560
 

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -3,10 +3,11 @@
 
 pkgname=rocm-core
 _pkgver_major=5
-_pkgver_minor=2
-_pkgver_patch=3
+_pkgver_minor=3
+_pkgver_patch=0
 _pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
-_pkgver_magic=109
+_pkgver_magic=63
+_pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
 pkgdesc='AMD ROCm core package'
@@ -15,15 +16,15 @@ url='https://docs.amd.com/'
 license=()
 depends=()
 makedepends=('cmake')
-source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/$pkgver/pool/main/${pkgname:0:1}/${pkgname}${pkgver}/${pkgname}${pkgver}_${pkgver}.$_pkgver_str-${_pkgver_magic}_amd64.deb"
+source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb"
         "rocm_version.c"
         "CMakeLists.txt")
-sha256sums=('21582613891053208e854457d795a68b89a66b04d4fe79967635f6b83aace206'
+sha256sums=('9755a7a06f29529c675bdf516b79d52c8b46c1cb7b5a3749221a2de379f594ef'
             '23ded36e5cf003be491e09e56b10982efb585b6bb93ae18884a8a160f0d9cae0'
             'ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560')
 
 prepare() {
-  tar -xf data.tar.xz
+  tar -xf data.tar.gz
 }
 
 build() {

--- a/rocm-hip-runtime/.SRCINFO
+++ b/rocm-hip-runtime/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-hip-runtime
 	pkgdesc = Packages to run HIP applications on the AMD platform
-	pkgver = 5.2.3
+	pkgver = 5.3.0
 	pkgrel = 1
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
@@ -11,7 +11,7 @@ pkgbase = rocm-hip-runtime
 	depends = rocm-llvm
 	depends = rocm-cmake
 	optdepends = hipify-clang: Translate CUDA code into HIP. Requires CUDA.
-	source = rocm-hip-runtime-5.2.3.deb::https://repo.radeon.com/rocm/apt/5.2.3/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.2.3.50203-109_amd64.deb
-	sha256sums = 1df85e151c7597d9ad1530658e555a73c4be0ab7e4a8b3289a2baaad9887e596
+	source = rocm-hip-runtime-5.3.0.deb::https://repo.radeon.com/rocm/apt/5.3/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.0.50300-63~22.04_amd64.deb
+	sha256sums = 69cef8d550af582666af0cec2e3315da9d7704b46cacca55b5adf087bf7d7cb8
 
 pkgname = rocm-hip-runtime

--- a/rocm-hip-runtime/PKGBUILD
+++ b/rocm-hip-runtime/PKGBUILD
@@ -3,9 +3,10 @@
 
 pkgname=rocm-hip-runtime
 _pkgver_major=5
-_pkgver_minor=2
-_pkgver_patch=3
-_pkgver_magic=109
+_pkgver_minor=3
+_pkgver_patch=0
+_pkgver_magic=63
+_pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
 pkgdesc="Packages to run HIP applications on the AMD platform"
@@ -15,8 +16,8 @@ license=()
 depends=('rocm-core' 'rocm-language-runtime' 'rocminfo' 'hip-runtime-amd' 'rocm-llvm' 'rocm-cmake')
 makedepends=()
 optdepends=('hipify-clang: Translate CUDA code into HIP. Requires CUDA.')
-source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)-${_pkgver_magic}_amd64.deb")
-sha256sums=('1df85e151c7597d9ad1530658e555a73c4be0ab7e4a8b3289a2baaad9887e596')
+source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb")
+sha256sums=('69cef8d550af582666af0cec2e3315da9d7704b46cacca55b5adf087bf7d7cb8')
 
 package() {
     tar -xf data.tar.gz


### PR DESCRIPTION
Updates for following `PKGBUILDS` (+`.SCRINFO`)

* hsa-amd-aqlprofile-bin -> 5.3.0-1
* rocm-core -> 5.3.0-1
* rocm-hip-runtime -> 5.3.0-1