### PR TITLE
hsa-rocr: explicitly set clang and llvm path to rocm-llvm

### DIFF
--- a/hsa-rocr/PKGBUILD
+++ b/hsa-rocr/PKGBUILD
@@ -25,7 +25,9 @@ build() {
     -B build \
     -S "$_dirname/src" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-    -DCMAKE_CXX_FLAGS='-DNDEBUG'
+    -DCMAKE_CXX_FLAGS='-DNDEBUG' \
+    -DClang_DIR=/opt/rocm/llvm/lib/cmake/clang \
+    -DLLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm
   cmake --build build
 }
 


### PR DESCRIPTION
To avoid `find_package` in [hsa-rocr's CMakeLists.txt][0] picking up older system clang and failing with unkown target ids.

Fixes: #899

[0]: https://github.com/RadeonOpenCompute/ROCR-Runtime/blob/adae6c61e10d371f7cbc3d0e94ae2c070cab18a4/src/core/runtime/trap_handler/CMakeLists.txt#L46