### PR TITLE
Missing '--hip-link' in CMAKE CXX FLAGS to link to HIP runtime... and exports in hsa-rocr

### DIFF
--- a/hipblas/PKGBUILD
+++ b/hipblas/PKGBUILD
@@ -23,6 +23,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
     -DBUILD_CLIENTS_SAMPLES=OFF \

--- a/hipcub/PKGBUILD
+++ b/hipcub/PKGBUILD
@@ -22,6 +22,7 @@ build() {
   cmake -Wno-dev -S "$_dirname" \
         -DCMAKE_INSTALL_PREFIX=/opt/rocm \
         -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+        -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
         -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr
 }
 

--- a/hipfft/PKGBUILD
+++ b/hipfft/PKGBUILD
@@ -24,6 +24,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DBUILD_CLIENTS_SAMPLES=OFF \
     -DBUILD_CLIENTS_TESTS=OFF

--- a/hipsolver/PKGBUILD
+++ b/hipsolver/PKGBUILD
@@ -23,6 +23,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm
   cmake --build build
 }

--- a/hipsparse/PKGBUILD
+++ b/hipsparse/PKGBUILD
@@ -26,6 +26,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DBUILD_CLIENTS_SAMPLES=OFF \
     -DBUILD_CLIENTS_TESTS=OFF

--- a/hsa-rocr/PKGBUILD
+++ b/hsa-rocr/PKGBUILD
@@ -20,6 +20,10 @@ sha256sums=('b51dbedbe73390e0be748b92158839c82d7fa0e514fede60aa7696dc498facf0')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
 
 build() {
+  export CXX=/opt/rocm/llvm/bin/clang++
+  export CC=/opt/rocm/llvm/bin/clang
+  export Clang_DIR=/opt/rocm/llvm/lib/cmake/clang
+  export LLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm
   cmake \
     -Wno-dev \
     -B build \

--- a/rccl/PKGBUILD
+++ b/rccl/PKGBUILD
@@ -25,6 +25,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/hip/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DBUILD_TESTS=OFF
   cmake --build build

--- a/rocalution/PKGBUILD
+++ b/rocalution/PKGBUILD
@@ -23,6 +23,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DROCM_PATH=/opt/rocm
   cmake --build build

--- a/rocblas/PKGBUILD
+++ b/rocblas/PKGBUILD
@@ -26,7 +26,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
-    -DCMAKE_CXX_FLAGS="--hip-link" \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DCMAKE_PREFIX_PATH=/opt/rocm/llvm/lib/cmake/llvm \
     -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \

--- a/rocblas/PKGBUILD
+++ b/rocblas/PKGBUILD
@@ -26,6 +26,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DCMAKE_PREFIX_PATH=/opt/rocm/llvm/lib/cmake/llvm \
     -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \

--- a/rocfft/PKGBUILD
+++ b/rocfft/PKGBUILD
@@ -25,6 +25,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm
   cmake --build build
 }

--- a/rocprim/PKGBUILD
+++ b/rocprim/PKGBUILD
@@ -23,6 +23,7 @@ build() {
     -S "$_dirname" \
     -B build \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
     -DBUILD_TEST=OFF \

--- a/rocrand/PKGBUILD
+++ b/rocrand/PKGBUILD
@@ -34,6 +34,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/hip/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -DBUILD_TEST=OFF
   cmake --build build

--- a/rocsolver/PKGBUILD
+++ b/rocsolver/PKGBUILD
@@ -50,6 +50,7 @@ build() {
       -B build \
       -S "$_dirname" \
       -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+      -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
       -DCMAKE_PREFIX_PATH="$srcdir/fmt-local/usr/lib/cmake/fmt" \
       -DCMAKE_INSTALL_PREFIX=/opt/rocm \
       -DROCSOLVER_EMBED_FMT=ON

--- a/rocsparse/PKGBUILD
+++ b/rocsparse/PKGBUILD
@@ -23,6 +23,7 @@ build() {
     -B build \
     -S "$_dirname" \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -Drocprim_DIR=/opt/rocm/rocprim/rocprim/lib/cmake/rocprim \
     -DBUILD_CLIENTS_SAMPLES=OFF

--- a/rocthrust/PKGBUILD
+++ b/rocthrust/PKGBUILD
@@ -23,6 +23,7 @@ build() {
     -S "$_dirname" \
     -B build \
     -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
+    -DCMAKE_CXX_FLAGS="--hip-link -Qunused-arguments" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
     -Damd_comgr_DIR=/opt/rocm/lib/cmake/amd_comgr \
     -DBUILD_TEST=OFF

--- a/roctracer/PKGBUILD
+++ b/roctracer/PKGBUILD
@@ -16,12 +16,14 @@ options=('!lto')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
 
 build() {
+  export Clang_DIR=/opt/rocm/llvm/lib/cmake/clang
   cmake \
     -B build \
     -Wno-dev \
     -S "$_dirname" \
     -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-    -DHIP_ROOT_DIR=/opt/rocm/hip
+    -DHIP_ROOT_DIR=/opt/rocm/hip \
+    -DCMAKE_HIP_FLAGS="--hip-link -Qunused-arguments"
   cmake --build build
 }
 


### PR DESCRIPTION
Missing '--hip-link' in CXX FLAGS, see:

"amdclang++ requires the --hip-link flag to be specified to link to the HIP runtime.  Alternatively, you could use the -L<dir> -lamdhip64 options to link to a HIP runtime library"
https://docs.amd.com/bundle/ROCm-Compiler-Reference-Guide-v5.3/page/Introduction_to_Compiler_Reference_Guide.html

If you do not want to pull the exports in hsa-rocr, fix the above according to AMD docs

Have fun!