### PR TITLE
Updates for rocm-core, hsa-amd-aqlprofile-bin and rocm-hip-runtime

### DIFF
--- a/hsa-amd-aqlprofile-bin/.SRCINFO
+++ b/hsa-amd-aqlprofile-bin/.SRCINFO
@@ -1,13 +1,13 @@
-pkgbase = hsa-amd-aqlprofile-bin
+pkgbase = hsa-amd-aqlprofile
 	pkgdesc = AQLPROFILE library for AMD HSA runtime API extension support
-	pkgver = 5.3.0
+	pkgver = 5.3.2
 	pkgrel = 1
 	url = https://docs.amd.com/
 	arch = x86_64
 	license = EULA
 	provides = hsa-amd-aqlprofile
 	conflicts = hsa-amd-aqlprofile
-	source = hsa-amd-aqlprofile-bin-5.3.0.tar.gz::http://repo.radeon.com/rocm/apt/5.3/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50300-63~22.04_amd64.deb
-	sha256sums = 46635f4f019aba1c3a53665430b0de70b992700e852f08b36f54ff33ca7e3ec7
+	source = hsa-amd-aqlprofile-5.3.2.deb::https://repo.radeon.com/rocm/apt/5.3.2/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50302-96~22.04_amd64.deb
+	sha256sums = 18a8279347137cd23e73d376501ec3e49502443817087aaf48fe5e7b51d6c9d5
 
 pkgname = hsa-amd-aqlprofile-bin

--- a/hsa-amd-aqlprofile-bin/PKGBUILD
+++ b/hsa-amd-aqlprofile-bin/PKGBUILD
@@ -1,12 +1,16 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 # Contributor: acxz <akashpatel at yahoo dot com>
 
-pkgname=hsa-amd-aqlprofile-bin
-_pkgname=hsa-amd-aqlprofile
-pkgver=5.3.0
-_pkgver=5.3
+pkgbase=hsa-amd-aqlprofile
+pkgname=${pkgbase}-bin
+_pkgver_major=5
+_pkgver_minor=3
+_pkgver_patch=2
+_pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
+_pkgver_magic=96
+_pkgver_ubunturel=22.04
+pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
-_debfile="hsa-amd-aqlprofile_1.0.0.50300-63~22.04_amd64.deb"
 pkgdesc='AQLPROFILE library for AMD HSA runtime API extension support'
 arch=('x86_64')
 url='https://docs.amd.com/'
@@ -14,13 +18,18 @@ license=('EULA')
 depends=()
 provides=('hsa-amd-aqlprofile')
 conflicts=('hsa-amd-aqlprofile')
-source=("$pkgname-$pkgver.tar.gz::http://repo.radeon.com/rocm/apt/${_pkgver}/pool/main/h/hsa-amd-aqlprofile/${_debfile}")
-sha256sums=('46635f4f019aba1c3a53665430b0de70b992700e852f08b36f54ff33ca7e3ec7')
+source=(# https://repo.radeon.com/rocm/apt/5.3.2/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50302-96~22.04_amd64.deb
+        "${pkgbase}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgbase:0:1}/${pkgbase}/${pkgbase}_1.0.0.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb")
+sha256sums=('18a8279347137cd23e73d376501ec3e49502443817087aaf48fe5e7b51d6c9d5')
+
+prepare() {
+  tar -xf data.tar.gz
+}
 
 package() {
-  tar -C "$pkgdir" -xf data.tar.gz
+  mv ${srcdir}/opt ${pkgdir}/opt
   rename -- "-$pkgver" '' "$pkgdir/opt/rocm-$pkgver"
-  rename -- "${_pkgname#hsa}" '' "$pkgdir/opt/rocm/$_pkgname"
+  rename -- "${pkgbase#hsa}" '' "$pkgdir/opt/rocm/$pkgbase"
   find "$pkgdir" -type d -exec chmod 755 '{}' '+'
   ln -sf "/opt/rocm/hsa/lib/libhsa-amd-aqlprofile64.so" "$pkgdir/opt/rocm/lib/libhsa-amd-aqlprofile64.so.1"
 }

--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = rocm-core
 	pkgdesc = AMD ROCm core package
-	pkgver = 5.3.0
+	pkgver = 5.3.2
 	pkgrel = 1
 	url = https://docs.amd.com/
 	arch = x86_64
 	makedepends = cmake
-	source = rocm-core-5.3.0.deb::https://repo.radeon.com/rocm/apt/5.3/pool/main/r/rocm-core/rocm-core_5.3.0.50300-63~22.04_amd64.deb
+	source = rocm-core-5.3.2.deb::https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-core/rocm-core_5.3.2.50302-96~22.04_amd64.deb
 	source = rocm_version.c
 	source = CMakeLists.txt
-	sha256sums = 9755a7a06f29529c675bdf516b79d52c8b46c1cb7b5a3749221a2de379f594ef
+	sha256sums = 7a79e38693c0c93b853166571d7f187e2bfb9a02ad5fb0075a44e49d72013f15
 	sha256sums = 23ded36e5cf003be491e09e56b10982efb585b6bb93ae18884a8a160f0d9cae0
 	sha256sums = ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560
 

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -4,9 +4,9 @@
 pkgname=rocm-core
 _pkgver_major=5
 _pkgver_minor=3
-_pkgver_patch=0
+_pkgver_patch=2
 _pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
-_pkgver_magic=63
+_pkgver_magic=96
 _pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
@@ -16,10 +16,11 @@ url='https://docs.amd.com/'
 license=()
 depends=()
 makedepends=('cmake')
-source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb"
+source=(# https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-core/rocm-core_5.3.2.50302-96~22.04_amd64.deb
+        "${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb"
         "rocm_version.c"
         "CMakeLists.txt")
-sha256sums=('9755a7a06f29529c675bdf516b79d52c8b46c1cb7b5a3749221a2de379f594ef'
+sha256sums=('7a79e38693c0c93b853166571d7f187e2bfb9a02ad5fb0075a44e49d72013f15'
             '23ded36e5cf003be491e09e56b10982efb585b6bb93ae18884a8a160f0d9cae0'
             'ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560')
 

--- a/rocm-hip-runtime/.SRCINFO
+++ b/rocm-hip-runtime/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-hip-runtime
 	pkgdesc = Packages to run HIP applications on the AMD platform
-	pkgver = 5.3.0
+	pkgver = 5.3.2
 	pkgrel = 1
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
@@ -11,7 +11,7 @@ pkgbase = rocm-hip-runtime
 	depends = rocm-llvm
 	depends = rocm-cmake
 	optdepends = hipify-clang: Translate CUDA code into HIP. Requires CUDA.
-	source = rocm-hip-runtime-5.3.0.deb::https://repo.radeon.com/rocm/apt/5.3/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.0.50300-63~22.04_amd64.deb
-	sha256sums = 69cef8d550af582666af0cec2e3315da9d7704b46cacca55b5adf087bf7d7cb8
+	source = rocm-hip-runtime-5.3.2.deb::https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.2.50302-96~22.04_amd64.deb
+	sha256sums = 0f14e1bc045ce41874612653264a4d465f2cd4f6a2f993b0992df788716d7b07
 
 pkgname = rocm-hip-runtime

--- a/rocm-hip-runtime/PKGBUILD
+++ b/rocm-hip-runtime/PKGBUILD
@@ -4,8 +4,9 @@
 pkgname=rocm-hip-runtime
 _pkgver_major=5
 _pkgver_minor=3
-_pkgver_patch=0
-_pkgver_magic=63
+_pkgver_patch=2
+_pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
+_pkgver_magic=96
 _pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
@@ -16,10 +17,14 @@ license=()
 depends=('rocm-core' 'rocm-language-runtime' 'rocminfo' 'hip-runtime-amd' 'rocm-llvm' 'rocm-cmake')
 makedepends=()
 optdepends=('hipify-clang: Translate CUDA code into HIP. Requires CUDA.')
-source=("${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb")
-sha256sums=('69cef8d550af582666af0cec2e3315da9d7704b46cacca55b5adf087bf7d7cb8')
+source=(# https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.2.50302-96~22.04_amd64.deb
+        "${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb")
+sha256sums=('0f14e1bc045ce41874612653264a4d465f2cd4f6a2f993b0992df788716d7b07')
+
+prepare() {
+  tar -xf data.tar.gz
+}
 
 package() {
-    tar -xf data.tar.gz
     install -Dm644 opt/rocm-${pkgver}/.info/version-hiprt "$pkgdir/opt/rocm/.info/version-hiprt"
 }


### PR DESCRIPTION
This is a bigger update for hsa-amd-aqlprofile, because it's prior structure was just very different and confusing to work with. Now it's based on the structure of rocm-core, so easier to update. For rocm-hip-runtime it was also a update, but a much smaller. Should work out for both of them. They do build and they do work for me.

**Update: rocm-core**

* rocm-core 5.3.2-1
* Update checksum
* Set link to new debian package

**Update: hsa-amd-aqlprofile-bin**

* hsa-amd-aqlprofile 5.3.2-1
* Update checksum
* Streamline pkgbuild structure, based on rocm-core

**Update: rocm-hip-runtime**

* rocm-hip-runtime 5.3.2-1
* Update checksum
* Set link to new debian package
* Streamline pkgbuild structure, based on rocm-core

