### PR TITLE
Updates for rocm-core, hsa-amd-aqlprofile-bin and rocm-hip-runtime (5.3.3)

### DIFF
--- a/hsa-amd-aqlprofile-bin/.SRCINFO
+++ b/hsa-amd-aqlprofile-bin/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = hsa-amd-aqlprofile-bin
 	pkgdesc = AQLPROFILE library for AMD HSA runtime API extension support
-	pkgver = 5.3.2
+	pkgver = 5.3.3
 	pkgrel = 1
 	url = https://docs.amd.com/
 	arch = x86_64
 	license = EULA
 	provides = hsa-amd-aqlprofile
 	conflicts = hsa-amd-aqlprofile
-	source = hsa-amd-aqlprofile-5.3.2.deb::https://repo.radeon.com/rocm/apt/5.3.2/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50302-96~22.04_amd64.deb
-	sha256sums = 18a8279347137cd23e73d376501ec3e49502443817087aaf48fe5e7b51d6c9d5
+	source = hsa-amd-aqlprofile-5.3.3.deb::https://repo.radeon.com/rocm/apt/5.3.3/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50303-99~22.04_amd64.deb
+	sha256sums = 69b4f2fb900a6e0a4ce20d8e8147772d8e68147275ada382c14534246e9cb997
 
 pkgname = hsa-amd-aqlprofile-bin

--- a/hsa-amd-aqlprofile-bin/PKGBUILD
+++ b/hsa-amd-aqlprofile-bin/PKGBUILD
@@ -5,9 +5,9 @@ _pkgbase=hsa-amd-aqlprofile
 pkgname=${_pkgbase}-bin
 _pkgver_major=5
 _pkgver_minor=3
-_pkgver_patch=2
+_pkgver_patch=3
 _pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
-_pkgver_magic=96
+_pkgver_magic=99
 _pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
@@ -18,9 +18,9 @@ license=('EULA')
 depends=()
 provides=('hsa-amd-aqlprofile')
 conflicts=('hsa-amd-aqlprofile')
-source=(# https://repo.radeon.com/rocm/apt/5.3.2/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50302-96~22.04_amd64.deb
+source=(# https://repo.radeon.com/rocm/apt/5.3.3/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50303-99~22.04_amd64.deb
         "${_pkgbase}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${_pkgbase:0:1}/${_pkgbase}/${_pkgbase}_1.0.0.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb")
-sha256sums=('18a8279347137cd23e73d376501ec3e49502443817087aaf48fe5e7b51d6c9d5')
+sha256sums=('69b4f2fb900a6e0a4ce20d8e8147772d8e68147275ada382c14534246e9cb997')
 
 prepare() {
   tar -xf data.tar.gz

--- a/rocm-core/.SRCINFO
+++ b/rocm-core/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = rocm-core
 	pkgdesc = AMD ROCm core package
-	pkgver = 5.3.2
+	pkgver = 5.3.3
 	pkgrel = 1
 	url = https://docs.amd.com/
 	arch = x86_64
 	makedepends = cmake
-	source = rocm-core-5.3.2.deb::https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-core/rocm-core_5.3.2.50302-96~22.04_amd64.deb
+	source = rocm-core-5.3.3.deb::https://repo.radeon.com/rocm/apt/5.3.3/pool/main/r/rocm-core/rocm-core_5.3.3.50303-99~22.04_amd64.deb
 	source = rocm_version.c
 	source = CMakeLists.txt
-	sha256sums = 7a79e38693c0c93b853166571d7f187e2bfb9a02ad5fb0075a44e49d72013f15
+	sha256sums = e5e37ac5492413f7145a848c8f2d6f6054d61ac784cc8a96b0bd3e979074f277
 	sha256sums = 23ded36e5cf003be491e09e56b10982efb585b6bb93ae18884a8a160f0d9cae0
 	sha256sums = ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560
 

--- a/rocm-core/PKGBUILD
+++ b/rocm-core/PKGBUILD
@@ -4,9 +4,9 @@
 pkgname=rocm-core
 _pkgver_major=5
 _pkgver_minor=3
-_pkgver_patch=2
+_pkgver_patch=3
 _pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
-_pkgver_magic=96
+_pkgver_magic=99
 _pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
@@ -16,11 +16,11 @@ url='https://docs.amd.com/'
 license=()
 depends=()
 makedepends=('cmake')
-source=(# https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-core/rocm-core_5.3.2.50302-96~22.04_amd64.deb
+source=(# https://repo.radeon.com/rocm/apt/5.3.3/pool/main/r/rocm-core/rocm-core_5.3.3.50303-99~22.04_amd64.deb
         "${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb"
         "rocm_version.c"
         "CMakeLists.txt")
-sha256sums=('7a79e38693c0c93b853166571d7f187e2bfb9a02ad5fb0075a44e49d72013f15'
+sha256sums=('e5e37ac5492413f7145a848c8f2d6f6054d61ac784cc8a96b0bd3e979074f277'
             '23ded36e5cf003be491e09e56b10982efb585b6bb93ae18884a8a160f0d9cae0'
             'ed98f0e1712e99b34d9da5ae7ade1e33847ef000760012bd5ed57170d9577560')
 

--- a/rocm-hip-runtime/.SRCINFO
+++ b/rocm-hip-runtime/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocm-hip-runtime
 	pkgdesc = Packages to run HIP applications on the AMD platform
-	pkgver = 5.3.2
+	pkgver = 5.3.3
 	pkgrel = 1
 	url = https://rocm-documentation.readthedocs.io/en/latest/
 	arch = x86_64
@@ -11,7 +11,7 @@ pkgbase = rocm-hip-runtime
 	depends = rocm-llvm
 	depends = rocm-cmake
 	optdepends = hipify-clang: Translate CUDA code into HIP. Requires CUDA.
-	source = rocm-hip-runtime-5.3.2.deb::https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.2.50302-96~22.04_amd64.deb
-	sha256sums = 0f14e1bc045ce41874612653264a4d465f2cd4f6a2f993b0992df788716d7b07
+	source = rocm-hip-runtime-5.3.3.deb::https://repo.radeon.com/rocm/apt/5.3.3/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.3.50303-99~22.04_amd64.deb
+	sha256sums = 47ecf61e51fd626be6f38e54e4b98c24869511a1d2df2c97f3ae0dde5b960753
 
 pkgname = rocm-hip-runtime

--- a/rocm-hip-runtime/PKGBUILD
+++ b/rocm-hip-runtime/PKGBUILD
@@ -4,9 +4,9 @@
 pkgname=rocm-hip-runtime
 _pkgver_major=5
 _pkgver_minor=3
-_pkgver_patch=2
+_pkgver_patch=3
 _pkgver_str="${_pkgver_major}$(printf '%02d' $_pkgver_minor $_pkgver_patch)"
-_pkgver_magic=96
+_pkgver_magic=99
 _pkgver_ubunturel=22.04
 pkgver=$_pkgver_major.$_pkgver_minor.$_pkgver_patch
 pkgrel=1
@@ -17,9 +17,9 @@ license=()
 depends=('rocm-core' 'rocm-language-runtime' 'rocminfo' 'hip-runtime-amd' 'rocm-llvm' 'rocm-cmake')
 makedepends=()
 optdepends=('hipify-clang: Translate CUDA code into HIP. Requires CUDA.')
-source=(# https://repo.radeon.com/rocm/apt/5.3.2/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.2.50302-96~22.04_amd64.deb
+source=(# https://repo.radeon.com/rocm/apt/5.3.3/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_5.3.3.50303-99~22.04_amd64.deb
         "${pkgname}-${pkgver}.deb::https://repo.radeon.com/rocm/apt/${pkgver/.0/}/pool/main/${pkgname:0:1}/${pkgname}/${pkgname}_${pkgver}.${_pkgver_str}-${_pkgver_magic}~${_pkgver_ubunturel}_amd64.deb")
-sha256sums=('0f14e1bc045ce41874612653264a4d465f2cd4f6a2f993b0992df788716d7b07')
+sha256sums=('47ecf61e51fd626be6f38e54e4b98c24869511a1d2df2c97f3ae0dde5b960753')
 
 prepare() {
   tar -xf data.tar.gz


### PR DESCRIPTION
This is a minor package update without additional changes to the PKGBUILDs.

**Update: rocm-hip-runtime**
    
   * rocm-hip-runtime 5.3.3
   * Update checksum
   * Set link to new debian package

**Update: hsa-amd-aqlprofile-bin**
    
   * hsa-amd-aqlprofile 5.3.3
   * Update checksum
   * Set link to new debian package

**Update: rocm-core**
    
   * rocm-core 5.3.3
   * Update checksum
   * Set link to new debian package