### PR TITLE
Allow to build without Supported GPU/Accelerator

### DIFF
--- a/hsakmt-roct/.SRCINFO
+++ b/hsakmt-roct/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hsakmt-roct
 	pkgdesc = Radeon Open Compute Thunk Interface
-	pkgver = 5.3.2
-	pkgrel = 2
+	pkgver = 5.3.3
+	pkgrel = 1
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/ROCt.html
 	arch = x86_64
 	license = MIT
@@ -11,7 +11,7 @@ pkgbase = hsakmt-roct
 	depends = pciutils
 	depends = libdrm
 	options = !lto
-	source = hsakmt-roct-5.3.2.tar.gz::https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-5.3.2.tar.gz
-	sha256sums = 0543bea35ff5c15c25772112d5cdcf1d1f173e2910b70f0192ad14fa5cc4ebea
+	source = hsakmt-roct-5.3.3.tar.gz::https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/archive/rocm-5.3.3.tar.gz
+	sha256sums = b5350de915997ed48072b37a21c2c44438028255f6cc147c25a196ad383c52e7
 
 pkgname = hsakmt-roct

--- a/hsakmt-roct/.SRCINFO
+++ b/hsakmt-roct/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = hsakmt-roct
 	pkgdesc = Radeon Open Compute Thunk Interface
 	pkgver = 5.3.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://rocmdocs.amd.com/en/latest/Installation_Guide/ROCt.html
 	arch = x86_64
 	license = MIT

--- a/hsakmt-roct/PKGBUILD
+++ b/hsakmt-roct/PKGBUILD
@@ -5,8 +5,8 @@
 # Contributor: Ranieri Althoff <ranisalt+aur at gmail.com>
 
 pkgname=hsakmt-roct
-pkgver=5.3.2
-pkgrel=2
+pkgver=5.3.3
+pkgrel=1
 pkgdesc='Radeon Open Compute Thunk Interface'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/ROCt.html'
@@ -16,7 +16,7 @@ makedepends=('cmake')
 checkdepends=('rocm-llvm')
 _git='https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface'
 source=("${pkgname}-${pkgver}.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
-sha256sums=('0543bea35ff5c15c25772112d5cdcf1d1f173e2910b70f0192ad14fa5cc4ebea')
+sha256sums=('b5350de915997ed48072b37a21c2c44438028255f6cc147c25a196ad383c52e7')
 options=(!lto)
 _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
 

--- a/hsakmt-roct/PKGBUILD
+++ b/hsakmt-roct/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=hsakmt-roct
 pkgver=5.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Radeon Open Compute Thunk Interface'
 arch=('x86_64')
 url='https://rocmdocs.amd.com/en/latest/Installation_Guide/ROCt.html'
@@ -32,24 +32,28 @@ build() {
 }
 
 check() {
-  local _tmpdir="$(mktemp -d -p $_dirname)"
-  DESTDIR="$_tmpdir" cmake --install build
+  # Test will fail if no supported AMD-GPU/Accelerator is available. Check for /dev/kfd and skip if not available
+  if [ -f /dev/kfd ]
+    then
+      local _tmpdir="$(mktemp -d -p $_dirname)"
+      DESTDIR="$_tmpdir" cmake --install build
 
-  LIBHSAKMT_PATH="$srcdir/$_tmpdir/opt/rocm" \
-  cmake \
-    -B kfd-build \
-    -Wno-dev \
-    -S "$_dirname/tests/kfdtest" \
-    -DCMAKE_BUILD_TYPE=None \
-    -DLLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm \
-    -DCMAKE_LINK_DIRECTORIES_BEFORE=ON
-  cmake --build kfd-build
+      LIBHSAKMT_PATH="$srcdir/$_tmpdir/opt/rocm" \
+      cmake \
+        -B kfd-build \
+        -Wno-dev \
+        -S "$_dirname/tests/kfdtest" \
+        -DCMAKE_BUILD_TYPE=None \
+        -DLLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm \
+        -DCMAKE_LINK_DIRECTORIES_BEFORE=ON
+      cmake --build kfd-build
 
-  cd kfd-build
-  # Stress tests cause system crash,
-  # https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/issues/76
-  LD_LIBRARY_PATH="$srcdir/$_tmpdir/opt/rocm" \
-  ./run_kfdtest.sh -e "KFDMemoryTest.LargestSysBufferTest:KFDMemoryTest.BigSysBufferStressTest:KFDQMTest.CreateQueueStressSingleThreaded"
+      cd kfd-build
+      # Stress tests cause system crash,
+      # https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/issues/76
+      LD_LIBRARY_PATH="$srcdir/$_tmpdir/opt/rocm" \
+      ./run_kfdtest.sh -e "KFDMemoryTest.LargestSysBufferTest:KFDMemoryTest.BigSysBufferStressTest:KFDQMTest.CreateQueueStressSingleThreaded"
+  fi
 }
 
 package() {


### PR DESCRIPTION
Changes:
upgpkg: hsakmt-roct 5.3.3-1
    
 * Patch release, update checksums
 * skip check()/tests on systems without /dev/kfd (AMD GPU/Accelerator)
    
This will essentially skip the check() routine if no /dev/kfd was found. This device is only available on systems with amdgpu (kmod) enabled and should be the base-line to make it build.
This change is important to have in build servers, where you might not have a GPU available.

fixes: #914