### PR TITLE
Update rocWMMA to 6.3.2

### DIFF
--- a/rocwmma/.SRCINFO
+++ b/rocwmma/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocwmma
 	pkgdesc = Library for accelerating mixed precision matrix multiplication
-	pkgver = 5.6.0
+	pkgver = 6.3.2
 	pkgrel = 1
 	url = https://rocwmma.readthedocs.io/en/latest/index.html
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = rocwmma
 	depends = hip
 	depends = rocblas
 	depends = openmp
-	source = rocwmma-5.6.0.tar.gz::https://github.com/ROCmSoftwarePlatform/rocWMMA/archive/rocm-5.6.0.tar.gz
-	sha256sums = 78b6ab10fce71d10a9d762b2eaab3390eb13b05c764f47a3b0a303ec3d37acf8
+	source = rocwmma-6.3.2.tar.gz::https://github.com/ROCm/rocWMMA/archive/rocm-6.3.2.tar.gz
+	sha256sums = f9dc5e837ac30efe4600775fb309e46ed8ef112a673435663d2ef7fdf28f8f12
 
 pkgname = rocwmma

--- a/rocwmma/PKGBUILD
+++ b/rocwmma/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 
 pkgname=rocwmma
-pkgver=5.6.0
+pkgver=6.3.2
 pkgrel=1
 pkgdesc='Library for accelerating mixed precision matrix multiplication'
 arch=('x86_64')
@@ -9,13 +9,13 @@ url='https://rocwmma.readthedocs.io/en/latest/index.html'
 license=('MIT')
 depends=('hip' 'rocblas' 'openmp')
 makedepends=('rocm-cmake' 'doxygen')
-_git='https://github.com/ROCmSoftwarePlatform/rocWMMA'
+_git='https://github.com/ROCm/rocWMMA'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
-sha256sums=('78b6ab10fce71d10a9d762b2eaab3390eb13b05c764f47a3b0a303ec3d37acf8')
+sha256sums=('f9dc5e837ac30efe4600775fb309e46ed8ef112a673435663d2ef7fdf28f8f12')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
 
 build() {
-    cmake \
+  CC=/opt/rocm/llvm/bin/amdclang CXX=/opt/rocm/llvm/bin/amdclang++ cmake \
       -Wno-dev \
       -B build \
       -S "$_dirname" \


### PR DESCRIPTION
This PR updates rocWMMA to version 6.3.2 (matching the ROCm packages now in extra-testing).