### PR TITLE
upgpkg: rocWMMA 1.7.0 for ROCm 6.4.0

### DIFF
--- a/rocwmma/.SRCINFO
+++ b/rocwmma/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = rocwmma
 	pkgdesc = Library for accelerating mixed precision matrix multiplication
-	pkgver = 6.3.2
+	pkgver = 6.4.0
 	pkgrel = 1
 	url = https://rocwmma.readthedocs.io/en/latest/index.html
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = rocwmma
 	depends = hip
 	depends = rocblas
 	depends = openmp
-	source = rocwmma-6.3.2.tar.gz::https://github.com/ROCm/rocWMMA/archive/rocm-6.3.2.tar.gz
-	sha256sums = f9dc5e837ac30efe4600775fb309e46ed8ef112a673435663d2ef7fdf28f8f12
+	source = rocwmma-6.4.0.tar.gz::https://github.com/ROCm/rocWMMA/archive/rocm-6.4.0.tar.gz
+	sha256sums = d95d53f70b4a2adc565bf4490515626cb7109f1d2e8a9978626610d3f178cf42
 
 pkgname = rocwmma

--- a/rocwmma/PKGBUILD
+++ b/rocwmma/PKGBUILD
@@ -20,7 +20,7 @@ build() {
       -B build \
       -S "$_dirname" \
       -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_BUILD_TYPE=None \
       -DROCWMMA_BUILD_TESTS=OFF \
       -DROCWMMA_BUILD_SAMPLES=OFF \
       -DCMAKE_POLICY_VERSION_MINIMUM=3.5

--- a/rocwmma/PKGBUILD
+++ b/rocwmma/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Torsten Keßler <t dot kessler at posteo dot de>
 
 pkgname=rocwmma
-pkgver=6.3.2
+pkgver=6.4.0
 pkgrel=1
 pkgdesc='Library for accelerating mixed precision matrix multiplication'
 arch=('x86_64')
@@ -11,7 +11,7 @@ depends=('hip' 'rocblas' 'openmp')
 makedepends=('rocm-cmake' 'doxygen')
 _git='https://github.com/ROCm/rocWMMA'
 source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
-sha256sums=('f9dc5e837ac30efe4600775fb309e46ed8ef112a673435663d2ef7fdf28f8f12')
+sha256sums=('d95d53f70b4a2adc565bf4490515626cb7109f1d2e8a9978626610d3f178cf42')
 _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
 
 build() {
@@ -20,9 +20,10 @@ build() {
       -B build \
       -S "$_dirname" \
       -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-      -DCMAKE_BUILD_TYPE=None \
+      -DCMAKE_BUILD_TYPE=Release \
       -DROCWMMA_BUILD_TESTS=OFF \
-      -DROCWMMA_BUILD_SAMPLES=OFF
+      -DROCWMMA_BUILD_SAMPLES=OFF \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   cmake --build build
 }
 


### PR DESCRIPTION
This PR updates rocWMMA to version 1.7.0 for ROCm 6.4.0 (already on extra repo).
I changed the build type to release, I don't know if there was a reason to keep it to none, if there was I'll just revert the change.